### PR TITLE
Fixing typo in code example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ define(
   function(defineComponent) {
     //..
   }
-};
+);
 ```
 
 `defineComponent` accepts any number of [mixin](#mixins) functions and returns a new Component constructor


### PR DESCRIPTION
The "How do I defined a component?" code example had the wrong closing brace.
