### PR TITLE
use instanceof instead of .jquery for speed + portability

### DIFF
--- a/lib/component.js
+++ b/lib/component.js
@@ -193,7 +193,7 @@ define(
           throw new Error("Component needs a node");
         }
 
-        if (node.jquery) {
+        if (node instanceof $) {
           this.node = node[0];
           this.$node = node;
         } else {


### PR DESCRIPTION
I was curious about the use of the `.jquery` property lookup on the `node` variable in component.js as compared to using `instanceof $`, so I set up a [jsperf](http://jsperf.com/jquery-vs-instanceof-jquery) to compare the two.

`instanceof` is faster than `.jquery` in all cases (bare element, string selector, or wrapped jQuery element) in Safari, Chrome, and Android 4.0.4, but much slower for the wrapped jQuery element case in Firefox (maybe something to do with V8's [hidden classes](https://developers.google.com/v8/design)?).

My main reason for this pull however, is portability. It's the only place in the code that specifically requires the jQuery API (zepto and ender dont have `.jquery` properties on their instances). 
