### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ this.defaultAttrs({
 
 this.selectMenuItem = function(e) {
   // toggle 'selected' class on all list items
-  this.select('menuItemSelector').toggleClass(this.attr.selectedClass);
+  this.select(this.attr.menuItemSelector).toggleClass(this.attr.selectedClass);
 
   //...
 };


### PR DESCRIPTION
It seems there was a typo using menuItemSelector as a string and not the attribute on the attr object.
