### PR TITLE
Correct wording for sample app section (gh-pages branch)

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
 
       <div class="site-main" role="main">
         <h2>Overview</h2>
-        <p>Flight is a lightweight, component-based JavaScript framework that maps behavior to DOM nodes. Twitter uses it for their web applications. By way of example, we've including a <a href="http://twitter.github.com/flight/demo">simple email client demo</a> (browse the <a href="https://github.com/twitter/flight/blob/gh-pages/demo">source code</a>) built over the Flight framework.</p>
+        <p>Flight is a lightweight, component-based JavaScript framework that maps behavior to DOM nodes. Twitter uses it for their web applications. By way of example, we've included a <a href="http://twitter.github.com/flight/demo">simple email client demo</a> (browse the <a href="https://github.com/twitter/flight/blob/gh-pages/demo">source code</a>) built over the Flight framework.</p>
         <p>Flight uses <a href="https://github.com/kriskowal/es5-shim">ES5-shim</a> and <a href="http://jquery.com">jQuery</a>. Additionally you will need to include an AMD implementation such as <a href="http://requirejs.org/">require.js</a> or <a href="https://github.com/danwrong/loadrunner">loadrunner</a>. Please read the <a href="https://github.com/twitter/flight/blob/master/README.md">Flight documentation</a> for installation instructions.</p>
 
 


### PR DESCRIPTION
This is effectively the same as #6, but corrects the wording in the `gh-pages` branch version of the README.
