### PR TITLE
`this.off` does not correctly detach callbacks bound more than one time

### DIFF
--- a/lib/component.js
+++ b/lib/component.js
@@ -94,6 +94,10 @@ define(
 
         callback = originalCb && originalCb.bind(this);
         callback.target = originalCb;
+		// if the original callback is already branded by jQuery's guid, copy it to the context-bound version
+		if (originalCb.guid) {
+			callback.guid = originalCb.guid;
+		}
 
         $element = (args.length == 2) ? $(args.shift()) : this.$node;
         type = args[0];

--- a/test/tests/events_spec.js
+++ b/test/tests/events_spec.js
@@ -65,6 +65,18 @@ provide(function(exports) {
         expect(spy).not.toHaveBeenCalled();
       });
 
+	  it('correctly unbinds multiple registered events for the same callback function using "off"', function() {
+		var instance1 = new Component(window.outerDiv);
+		var spy = jasmine.createSpy();
+		instance1.on(document, 'event1', spy);
+		instance1.on(document, 'event2', spy);
+		instance1.off(document, 'event1', spy);
+		instance1.off(document, 'event2', spy);
+		instance1.trigger('event1');
+		instance1.trigger('event2');
+		expect(spy).not.toHaveBeenCalled();
+	  });
+
       it('bubbles custom events between components', function() {
         var instance1 = new Component(window.innerDiv);
         var instance2 = new Component(window.outerDiv);


### PR DESCRIPTION
Fiddle demonstrating this issue (against master): http://jsfiddle.net/scottrabin/Vb89D/1/

When multiple events are bound to the same callback function, attempting to remove the events via `this.off(sameElem, sameEvent, fn)` does not correctly remove the bound event.

This pull request introduces the fix (copy the `guid` assigned to the original callback, if it exists, to the context-bound callback generated during `component.on(...)`) as well as a test case for this bug.

_Commit Notes:_
Copy function `guid` to context-bound version

jQuery internally relies on unique `guid` values to ensure that the
correct function is removed from an element in `$(element).off('event',
func);`. Previously, `component.on` would attach the `guid` value to the
original callback to preserve this functionality in jQuery. However,
future calls to `.on('event', sameFunc)` would fail to check the
original callback for this `guid` value and simply overwrite it with
whatever new `guid` was assigned by jQuery. This change preserves the
original `guid` value across multiple calls to `on` with the same
function.
