### PR TITLE
Updating require.js path in readme doc example

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ These files are loaded in the sample app at `demo/index.html`.
 <script src='components/jquery/jquery.js'></script>
 <script src='components/es5-shim/es5-shim.js'></script>
 <script src='components/es5-shim/es5-sham.js'></script>
-<script data-main="requireMain.js" src='components/requirejs/requirejs.js'></script>
+<script data-main="requireMain.js" src='components/requirejs/require.js'></script>
 ```
 
 ## How do I use it?


### PR DESCRIPTION
Path was `requirejs.js`, but is actually `require.js` in component directory.
