### PR TITLE
allow to pass data parameter in trigger as string

### DIFF
--- a/lib/component.js
+++ b/lib/component.js
@@ -54,7 +54,7 @@ define(
         var $element, type, data;
         var args = utils.toArray(arguments);
 
-        if (typeof args[args.length - 1] != "string") {
+        if (args.length > 1) {
           data = args.pop();
         }
 

--- a/test/tests/events_spec.js
+++ b/test/tests/events_spec.js
@@ -146,6 +146,18 @@ provide(function(exports) {
         expect(returnedData.sheep).toBe('thrilling');
       });
 
+      it("allows to pass data parameter as string", function() {
+        var instance = new Component(document.body);
+        var data = "cool";
+
+        var spy = jasmine.createSpy();
+        instance.on(document, 'foo', spy);
+        instance.trigger('foo', data);
+        var args = spy.mostRecentCall.args;
+        expect(args[0]).toEqual(jasmine.any($.Event));
+        expect(args[1]).toBe(data);
+      });
+
       exports(1);
     });
   });


### PR DESCRIPTION
I ran into this issue when I tried to pass string as a data parameter in one of the components. For example:

``` js
this.trigger('eventName', 'string');
```

Based on the implementation and specs I assumed that the first argument in `trigger` always represents event name and the the last argument (if present) represents data parameter. 

PS sorry about the `No newline at end of file`. I have to research how to turn it off.
