### PR TITLE
Fixed Sent folder update after email is sent

### DIFF
--- a/demo/app/component_data/compose_box.js
+++ b/demo/app/component_data/compose_box.js
@@ -79,7 +79,7 @@ define(
           subject: data.subject,
           message: data.message
         });
-        this.trigger('dataMailItemsRefreshRequested', data.currentFolder);
+        this.trigger('dataMailItemsRefreshRequested', {folder: data.currentFolder});
       };
 
       this.after("initialize", function() {


### PR DESCRIPTION
There was a bug: 
1. Open Sent folder
2. Click 'New' buttons and send email.

AR: sent folder is not updated.
ER: just sent email should appear on Sent folder.

There reason is wrong call to trigger method, that required to have an `object` as payload.
