### PR TITLE
Removing unnecessary variable.

### DIFF
--- a/lib/component.js
+++ b/lib/component.js
@@ -94,13 +94,13 @@ define(
           data = $.extend(true, {}, this.attr.eventData, data);
         }
 
-        var returnVal = $element.trigger((event || type), data);
+        $element.trigger((event || type), data);
 
         if (defaultFn && !event.isDefaultPrevented()) {
           (this[defaultFn] || defaultFn).call(this);
         }
 
-        return returnVal;
+        return $element;
       };
 
       this.on = function() {


### PR DESCRIPTION
Return value of trigger() will be $element, so we can just return that.
