### PR TITLE
Add callback trigger function

### DIFF
--- a/lib/component.js
+++ b/lib/component.js
@@ -103,6 +103,13 @@ define(
         return $element;
       };
 
+      this.thenTrigger = function(event) {
+        return $.proxy(function() {
+          var args = utils.toArray(arguments);
+          this.trigger(event, args);
+        }, this);
+      };
+
       this.on = function() {
         var $element, type, callback, originalCb;
         var args = utils.toArray(arguments);


### PR DESCRIPTION
I find myself constantly wanting to trigger an event on execution of a callback (eg. Trigger an event on an ajax response).

``` javascript
this.doSomething = function() {
  $.get('/hello', $.proxy(function() { 
    this.trigger('world', arguments); 
  }, this)); 
}
```

Not sure if other people are doing this or a lot or just myself! This pull request adds a new `thenTrigger()` method to component.js to simplify the process of triggering an event on the calling component on execution of a callback.

eg.

``` javascript
this.doSomething = function() {
  $.get('/hello', this.thenTrigger('world');
}

this.on('world', function(e, res) {
  // Arguments are passed through if needed.
  console.log(res);
});
```

Is this something that would help others?
