### PR TITLE
Relaxing Utils#push protections to allow components to override #defaultAttrs already set in a mixin

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -66,7 +66,7 @@ define(
       },
 
       // updates base in place by copying properties of extra to it
-      // optionally clobber protected
+      // optionally clobber protected (preserving base)
       // usage:
       //   var base = {a:2, b:6};
       //   var extra = {c:4};
@@ -75,8 +75,7 @@ define(
       //
       //   var base = {a:2, b:6};
       //   var extra = {b: 4 c:4};
-      //   push(base, extra, true); //Error ("utils.push attempted to overwrite 'b' while running in protected mode")
-      //   base; //{a:2, b:6}
+      //   base; //{a:2, b:6, c:4}
       //
       // objects with the same key will merge recursively when protect is false
       // eg:
@@ -87,15 +86,14 @@ define(
       push: function(base, extra, protect) {
         if (base) {
           Object.keys(extra || {}).forEach(function(key) {
-            if (base[key] && protect) {
-              throw Error("utils.push attempted to overwrite '" + key + "' while running in protected mode");
-            }
+            //skip is protect and attr already set (even if null)
+            if (protect && (typeof base[key] !== 'undefined')) return;
 
             if (typeof base[key] == "object" && typeof extra[key] == "object") {
               //recurse
               this.push(base[key], extra[key]);
             } else {
-              //no protect, so extra wins
+              //extra wins
               base[key] = extra[key];
             }
           }, this);

--- a/test/tests/constructor_spec.js
+++ b/test/tests/constructor_spec.js
@@ -100,10 +100,10 @@ define(['lib/component'], function (defineComponent) {
       TestComponent.teardownAll();
     });
 
-    it('throws error when core and mixin defaults overlap', function () {
-      expect(function () {
-        defineComponent(testComponentDefaultAttrs, withBadDefaults);
-      }).toThrow("utils.push attempted to overwrite 'core' while running in protected mode");
+    it('does not overrwrite core when core and mixin defaults overlap', function() {
+      var TestComponent = defineComponent(testComponentDefaultAttrs, withBadDefaults);
+      var instance = new TestComponent(document.body);
+      expect(instance.attr.core).toBe(35);
     });
 
   });

--- a/test/tests/utils_spec.js
+++ b/test/tests/utils_spec.js
@@ -154,10 +154,12 @@ define(['lib/component', 'lib/utils'], function (defineComponent, util) {
         expect(pushed.c).toBe(44);
       });
 
-      it('does not overwrite properties when protect is true', function () {
-        expect(function () {
-          util.push(foo, moo, true);
-        }).toThrow("utils.push attempted to overwrite 'b' while running in protected mode");
+      it('does not overwrite properties when protect is true', function() {
+        var pushed = util.push(foo, moo, true);
+        expect(pushed.a).toBe(32);
+        expect(pushed.b.aa).toBe(33);
+        expect(pushed.b.bb).toBe(94);
+        expect(pushed.d).toBe(78);
       });
 
       it('recursively merges like properties when protect is false', function () {


### PR DESCRIPTION
Really interesting project, thanks for sharing!

I was reading through the demo app, and noticed that in the `with_select` mixin, there are a few attributes that it uses as part of its core functionality, including the name of the class to apply to selected elements (`selected`) and the name of the event to fire when selection changes (`selectionChangedEvent`).  These are expected to be defined on the component by event time when they need to be used by the mixin.

This is clear reading through the source, but I was expecting to see them defined in the call to `defaultAttrs.`  I added them in and was surprised to find that this won't work if other components consuming the mixin also define defaults for those attributes (e.g., `mail_items`), since Component#defaultAttrs is strict when merging those attributes in.

I see the desire to want to make option clobbering throw an exception, but it seems like a common pattern is to have a mixin define a default attribute and then have a consuming component specify a more specific default.  Since the ordering is reversed in the mixing-in process (i.e., component first, then mixin), it effectively means that if mixins have defaults it prevents consuming components from providing defaults of its own for those attributes.

So I patched the Utils#push method to change the meaning of the `protect` argument, since it didn't look like it was being used in any other code.  Instead of throwing an exception, the `base` object just wins when there is a conflict between it and the `extra`.  This makes sense here since it's the #defaultsAttr method calling it - you don't need the default attribute value if one is already set, so no harm done.

Another benefit of this would be that mixins could now use #defaultAttrs to declare what attributes they expected to be provided by mix-in time.  I also update the demo app to use this (which I'll submit in a separate PR).

Curious to hear what you think, or if there are other side effects I'm inadvertently introducing here.  Thanks!
