### PR TITLE
retain DOM selector in  of attached component

### DIFF
--- a/lib/component.js
+++ b/lib/component.js
@@ -185,7 +185,8 @@ define(
       var options = utils.merge.apply(utils, utils.toArray(arguments, 1));
 
       $(selector).each(function(i, node) {
-        new this(node, options);
+        var component = new this(node, options);
+        component.$node.selector = selector;
       }.bind(this));
     }
 

--- a/test/run/unit_test_files.js
+++ b/test/run/unit_test_files.js
@@ -5,5 +5,6 @@ runTests([
   'test/tests/instance_spec',
   'test/tests/mixin_spec',
   'test/tests/registry_spec',
-  'test/tests/utils_spec'
+  'test/tests/utils_spec',
+  'test/tests/component_spec'
 ]);

--- a/test/tests/component_spec.js
+++ b/test/tests/component_spec.js
@@ -1,0 +1,25 @@
+"use strict";
+
+define(['lib/component'], function (defineComponent) {
+
+  describe('attachTo', function() {
+
+    var $node;
+
+    var Component = (function () {
+      return defineComponent(function testComponent() {
+        this.after('initialize', function() {
+          $node = this.$node;
+        })
+      });
+    })();
+
+
+    it('should retain DOM selector in $node of attached component', function() {
+      Component.attachTo('body');
+      expect($node.selector).toEqual('body');
+    });
+
+  });
+
+});


### PR DESCRIPTION
The problem is I want to know the DOM selector string in an attached component. Since it has reference to the attaching node, I expect this to work: `this.$node.selector`.
