### PR TITLE
Namespaced event types

### DIFF
--- a/lib/component.js
+++ b/lib/component.js
@@ -123,7 +123,7 @@ define(
 
         if (lastIndex == 2) {
           $element = $(arguments[0]);
-          type = arguments[1] + '.' + this.identity;
+          type = arguments[1];
         } else {
           $element = this.$node;
           type = arguments[0];
@@ -160,7 +160,7 @@ define(
 
         if (lastIndex == 1) {
           $element = $(arguments[0]);
-          type = arguments[1] + '.' + this.identity;
+          type = arguments[1];
         } else {
           $element = this.$node;
           type = arguments[0];

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -92,6 +92,7 @@ define(
       function InstanceInfo(instance) {
         this.instance = instance;
         this.events = [];
+        this.namespace = '.' + instance.identity;
 
         this.addBind = function(event) {
           this.events.push(event);
@@ -104,7 +105,7 @@ define(
               this.events.splice(i, 1);
             }
           }
-        }
+        };
       }
 
       this.addInstance = function(instance) {
@@ -166,30 +167,50 @@ define(
       };
 
       this.on = function(componentOn) {
-        var instance = registry.findInstanceInfo(this), boundCallback;
+        var instanceInfo = registry.findInstanceInfo(this),
+            otherArgs = prepareEventArguments(arguments),
+            eventArgs = otherArgs.slice(),
+            boundCallback;
 
-        // unpacking arguments by hand benchmarked faster
-        var l = arguments.length, i = 1;
-        var otherArgs = new Array(l - 1);
-        for (; i < l; i++) otherArgs[i - 1] = arguments[i];
+        if (instanceInfo) {
+          // add namespace to event type
+          var typeIndex = ( eventArgs.length == 3 ) ? 1 : 0
+          eventArgs[typeIndex] += instanceInfo.namespace;
 
-        if (instance) {
-          boundCallback = componentOn.apply(null, otherArgs);
+          boundCallback = componentOn.apply(null, eventArgs);
           if (boundCallback) {
             otherArgs[otherArgs.length-1] = boundCallback;
           }
+
           var event = parseEventArgs(this, otherArgs);
-          instance.addBind(event);
+          instanceInfo.addBind(event);
         }
       };
 
-      this.off = function(el, type, callback) {
-        var event = parseEventArgs(this, arguments),
-            instance = registry.findInstanceInfo(this);
+      this.off = function(componentOff) {
+        var instanceInfo = registry.findInstanceInfo(this),
+            otherArgs = prepareEventArguments(arguments),
+            eventArgs = otherArgs.slice();
 
-        if (instance) {
-          instance.removeBind(event);
+        if (instanceInfo) {
+          // add namespace to event type
+          var typeIndex = ( eventArgs.length == 3 ) ? 1 : 0
+          eventArgs[typeIndex] += instanceInfo.namespace;
+
+          componentOff.apply(null, eventArgs);
+
+          var event = parseEventArgs(this, otherArgs);
+          instanceInfo.removeBind(event);
         }
+      };
+
+      // unpacking arguments by hand benchmarked faster
+      function prepareEventArguments( args ) {
+        var l = args.length, i = 1;
+        var otherArgs = new Array(l - 1);
+        for (; i < l; i++) otherArgs[i - 1] = args[i];
+
+        return otherArgs;
       };
 
       //debug tools may want to add advice to trigger
@@ -207,7 +228,7 @@ define(
         });
 
         this.around('on', registry.on);
-        this.after('off', registry.off);
+        this.around('off', registry.off);
         //debug tools may want to add advice to trigger
         window.DEBUG && DEBUG.enabled && this.after('trigger', registry.trigger);
         this.after('teardown', {obj:registry, fnName:'teardown'});

--- a/test/tests/events_spec.js
+++ b/test/tests/events_spec.js
@@ -76,6 +76,28 @@ define(['lib/component'], function (defineComponent) {
       expect(spy).not.toHaveBeenCalled();
     });
 
+    it('correctly unbinds multiple registered events for the same callback function using "teardown"', function () {
+      var instance1 = new Component(window.outerDiv);
+      var spy = jasmine.createSpy();
+      instance1.on(document, 'event1', spy);
+      instance1.on(document, 'event2', spy);
+      instance1.teardown();
+      instance1.trigger('event1');
+      instance1.trigger('event2');
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('correctly unbinds multiple registered events for the same callback function using "teardownAll"', function () {
+      var instance1 = new Component(window.outerDiv);
+      var spy = jasmine.createSpy();
+      instance1.on(document, 'event1', spy);
+      instance1.on(document, 'event2', spy);
+      Component.teardownAll();
+      instance1.trigger('event1');
+      instance1.trigger('event2');
+      expect(spy).not.toHaveBeenCalled();
+    });
+
     it('does not unbind those registered events that share a callback, but were not sent "off" requests', function () {
       var instance1 = new Component(window.outerDiv);
       var spy = jasmine.createSpy();

--- a/test/tests/registry_spec.js
+++ b/test/tests/registry_spec.js
@@ -63,6 +63,7 @@ define(['lib/component', 'lib/registry'], function (defineComponent, registry) {
       expect(event.callback.target).toBe(myFunction);
 
       instance.off("myEvent");
+
       expect(instanceInfo.events.length).toBeFalsy();
     });
 


### PR DESCRIPTION
Taken this function:

``` javascript
this.on( document, 'resize', this.resize )
```

Then:

``` javascript
this.teardown() or this.off( document, 'resize', this.resize )
```

Will not just remove the instance's listener, but all of the component instance's listeners.

The easiest solution is to namespace the event type:

``` javascript
this.on( document, 'resize' + '.' + this.identity, this.resize )
```

and

``` javascript
this.off( document, 'resize' + '.' + this.identity, this.resize )
```

But it is also possible to add the namespace automatically when set.
