### PR TITLE
Expects jQuery to be available through global $ variable instead of loaded as a module

### DIFF
--- a/lib/component.js
+++ b/lib/component.js
@@ -9,6 +9,7 @@
 define(
 
   [
+    'jquery',
     './advice',
     './utils',
     './compose',
@@ -17,7 +18,7 @@ define(
     '../tools/debug/debug'
   ],
 
-  function(advice, utils, compose, registry, withLogging, debug) {
+  function($, advice, utils, compose, registry, withLogging, debug) {
 
     var functionNameRegEx = /function (.*?)\s?\(/;
     var componentId = 0;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -8,9 +8,11 @@
 
 define(
 
-  [],
+  [
+    'jquery'
+  ],
 
-  function () {
+  function ($) {
 
     var arry = [];
     var DEFAULT_INTERVAL = 100;


### PR DESCRIPTION
Flight uses the global `$` variable to access jQuery throughout the code. 

Like this:

``` javascript
$element = $(arguments[0]);
```

But since Flight is built on using an AMD module loader and everything is a module, jQuery should also be loaded as an AMD module and assigned to the `$` variable in the module definition.

Like this (`flight/lib/component.js`):

``` javascript
define(
  [
    'jquery',
    './advice',
    './utils',
    './compose',
    './registry',
    './logger',
    '../tools/debug/debug'
  ],
  function($, advice, utils, compose, registry, withLogging, debug) {
    ...
```
