### PR TITLE
spotted a typo in resolveDelegateRules

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -145,7 +145,7 @@ define(
       var rules = {};
 
       Object.keys(ruleInfo).forEach(function(r) {
-        if (!r in this.attr) {
+        if (!(r in this.attr)) {
           throw new Error('Component "' + this.toString() + '" wants to listen on "' + r + '" but no such attribute was defined.');
         }
         rules[this.attr[r]] = ruleInfo[r];


### PR DESCRIPTION
as you know this will never work as expected:

``` javascript
if (!'nope' in {test:1}) alert('never');
if (!'test' in {test:1}) alert('never');
```

since `!whatever in object` is interpreted as `false in object` due operator precedence.

I believe that's just a typo, fixed here so that:

``` javascript
if (!('nope' in {test:1})) alert('ooops');
```

will work as expected.
