### PR TITLE
Add link to Flight components list

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ write, and test your application.
   Recommended. One-step to setup everything you need to write and test a
   standalone Flight component.
 
+* [Flight components list](http://flight-components.jit.su)
+  Recommended. View all Flight components available.
+
 * [Jasmine Flight](https://github.com/flightjs/jasmine-flight/)
   Extensions for the Jasmine test framework.
 


### PR DESCRIPTION
[Flight components list](http://flight-components.jit.su)

I know that the idea is to have a list of all the components integrated into the new website, but at the moment we don't have any place to show the growing list of Flight components. 

This is a simple site that gets a list of all Bower components and the filters them to only show the ones starting with "flight-". I know that it still has a LOT of room for improvement, like caching the request to Bower instead of doing it on every page load. [rogeliog/flight-components-app](github.com/rogeliog/flight-components-app)

:)
