### PR TITLE
Fixed trigger of event fired not on this.$node

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -31,6 +31,24 @@ define(
     }
   }
 
+  //checks is object instanceof jQuery, HTMLElement, HTMLDocument or current window
+  function checkIsDomOrJQueryObject(object) {
+    var isHTMLClassesReady = HTMLElement && HTMLDocument;
+    if (window == object) {
+      return true;
+    }
+    if (object instanceof jQuery) {
+      return true;
+    }
+    if (isHTMLClassesReady) {
+      return object instanceof HTMLElement || object instanceof HTMLDocument;
+    } else {
+      //shim for old browsers, tested in IE7
+      return 'childNodes' in object;
+    }
+    return false;
+  }
+
   function withBase() {
 
     // delegate trigger, bind and unbind to an element
@@ -48,7 +66,7 @@ define(
         data = lastArg;
       }
 
-      if (lastIndex == 1) {
+      if (checkIsDomOrJQueryObject(arguments[0])) {
         $element = $(arguments[0]);
         event = arguments[1];
       } else {
@@ -93,7 +111,7 @@ define(
         originalCb = origin;
       }
 
-      if (lastIndex == 2) {
+      if (checkIsDomOrJQueryObject(arguments[0])) {
         $element = $(arguments[0]);
         type = arguments[1];
       } else {
@@ -130,7 +148,7 @@ define(
         lastIndex -= 1;
       }
 
-      if (lastIndex == 1) {
+      if (checkIsDomOrJQueryObject(arguments[0])) {
         $element = $(arguments[0]);
         type = arguments[1];
       } else {


### PR DESCRIPTION
if you try to 

``` javascript
    this.trigger(document, 'someEvent', {dataForEvent: 'asdsad'}) 
```

it will not work and will an exception.
fix provided.
