### PR TITLE
Add support for jQuery 'one' method

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -81,7 +81,7 @@ define(
     };
 
     this.on = function() {
-      var $element, type, callback, originalCb;
+      var $element, type, one, callback, originalCb;
       var lastIndex = arguments.length - 1, origin = arguments[lastIndex];
 
       if (typeof origin == "object") {
@@ -92,13 +92,18 @@ define(
       } else {
         originalCb = origin;
       }
-
-      if (lastIndex == 2) {
+      if (lastIndex == 3) {
+        $element = $(arguments[0]);
+        type = arguments[1];
+        one = arguments[2];
+      } else
+      if (lastIndex == 2 && arguments[lastIndex-1] !== 1) {
         $element = $(arguments[0]);
         type = arguments[1];
       } else {
         $element = this.$node;
         type = arguments[0];
+        one = arguments[1];
       }
 
       if (typeof originalCb != 'function' && typeof originalCb != 'object') {
@@ -113,7 +118,7 @@ define(
         callback.guid = originalCb.guid;
       }
 
-      $element.on(type, callback);
+      $element.on(type, null, null, callback, one);
 
       // get jquery's guid from our bound fn, so unbinding will work
       originalCb.guid = callback.guid;
@@ -139,6 +144,12 @@ define(
       }
 
       return $element.off(type, callback);
+    };
+
+    this.one = function() {
+      var args = Array.prototype.slice.call(arguments);
+      args.splice(args.length-1, 0, 1);
+      this.on.apply(this, args);
     };
 
     this.resolveDelegateRules = function(ruleInfo) {

--- a/test/spec/events_spec.js
+++ b/test/spec/events_spec.js
@@ -234,5 +234,41 @@ define(['lib/component'], function (defineComponent) {
       expect(spy).not.toHaveBeenCalled();
     });
 
+    it('does trigger the event multiple times', function() {
+      var instance1 = (new Component).initialize(window.innerDiv);
+
+      var spy = jasmine.createSpy();
+      instance1.on(document, 'click', spy);
+      instance1.trigger('click');
+      expect(spy).toHaveBeenCalled();
+      instance1.trigger('click');
+      expect(spy.callCount).toBe(2);
+    });
+
+    describe ('"one" method', function() {
+
+      it('does not trigger the event more than once', function() {
+        var instance = (new Component).initialize(window.innerDiv);
+
+        var spy = jasmine.createSpy();
+        instance.one(document, 'click', spy);
+        instance.trigger('click');
+        expect(spy).toHaveBeenCalled();
+        instance.trigger('click');
+        expect(spy.callCount).toBe(1);
+      });
+
+      it('correctly passes args when no explicit node argument', function() {
+        var instance = (new Component).initialize(window.innerDiv);
+
+        var spy = jasmine.createSpy();
+        instance.one('click', spy);
+        instance.trigger('click');
+        expect(spy).toHaveBeenCalled();
+        instance.trigger('click');
+        expect(spy.callCount).toBe(1);
+      });
+
+    });
   });
 });


### PR DESCRIPTION
- Add 'one' method that inserts extra arg and passes to 'on'.
- Update parse of arguments in 'on' so 'one' arg is passed to jQuery (has this got too hairy?).
- Add control test for 'on'.
- Add tests for new 'one' method.

I had a use case for this in a component in TweetDeck. Trivial to work around of course, but nice if it just worked for people familiar with it from jQuery?
