### PR TITLE
Change the function object constructor to a function literal to avoid CSP errors.

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -200,7 +200,7 @@ define(
       };
 
       //debug tools may want to add advice to trigger
-      registry.trigger = new Function;
+      registry.trigger = function() {};
 
       this.teardown = function() {
         registry.removeInstance(this);


### PR DESCRIPTION
`new Function` triggers Content-Security-Policies without `script-src 'unsafe-eval'` in them. Even though this is [a bug in Chrome](https://code.google.com/p/chromium/issues/detail?id=265255) (haven't tested any other browsers) it could be easily avoided by using a function literal instead.
