### PR TITLE
Add ability to select multiple attribute keys

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -158,8 +158,12 @@ define(
       utils.push(this.defaults, defaults, true) || (this.defaults = defaults);
     };
 
-    this.select = function(attributeKey) {
-      return this.$node.find(this.attr[attributeKey]);
+    this.select = function() {
+      var attributeKeys = utils.toArray(arguments);
+      var selector = attributeKeys.map(function(attributeKey) {
+        return this.attr[attributeKey];
+      }, this).filter(String).join(', ');
+      return this.$node.find(selector);
     };
 
     this.initialize = function(node, attrs) {


### PR DESCRIPTION
Hi guys,

I find useful to be able to pass multiple attributes to the `.select` method.

Example:

``` javascript
this.defaultAttrs({
  menuTitleSelector: '.menu-title',
  menuItemSelector:  '.menu-item'
});

this.selectMenu = function(e) {
  return this.select('menuTitleSelector', 'menuItemSelector');
};
```

What do you think?

Thanks!
