### PR TITLE
only assign identity if none exists

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -173,8 +173,9 @@ define(
       };
 
       this.initialize = function(node, attrs) {
-        attrs = attrs || {};
-        this.identity = componentId++;
+        attrs || (attrs = {});
+        //only assign identity if there isn't one (initialize can be called multiple times)
+        this.identity || (this.identity = componentId++);
 
         if (!node) {
           throw new Error('Component needs a node');


### PR DESCRIPTION
now that initialize can be called multiple times per instance we should ensure existing identities are not updated
