### PR TITLE
Remove jquery wrong and unecessary test from attachTo component function

### DIFF
--- a/lib/component.js
+++ b/lib/component.js
@@ -55,9 +55,8 @@ define(
       var options = utils.merge.apply(utils, args);
 
       $(selector).each(function(i, node) {
-        var rawNode = node.jQuery ? node[0] : node;
         var componentInfo = registry.findComponentInfo(this);
-        if (componentInfo && componentInfo.isAttachedTo(rawNode)) {
+        if (componentInfo && componentInfo.isAttachedTo(node)) {
           // already attached
           return;
         }


### PR DESCRIPTION
jQuery version is stored at `jquery` property instead of `jQuery`.
Plus, I think is not common to have a jQuery object inside another.
