### PR TITLE
Fix shared node event handler off bug.

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -118,15 +118,7 @@ define(
         callback = originalCb.bind(this);
         callback.target = originalCb;
 
-        // if the original callback is already branded by jQuery's guid, copy it to the context-bound version
-        if (originalCb.guid) {
-          callback.guid = originalCb.guid;
-        }
-
         $element.on(type, callback);
-
-        // get jquery's guid from our bound fn, so unbinding will work
-        originalCb.guid = callback.guid;
 
         return callback;
       };

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -47,6 +47,28 @@ define(
       );
     }
 
+    function findEventsByTarget(events, target) {
+      var matches = [];
+      for (var i = 0, e; e = events[i]; i++) {
+        if (e.callback &&
+            e.callback.target === target) {
+          matches.push(e);
+        }
+      }
+      return matches;
+    };
+
+    function unpackArgs(originalArgs, offset) {
+      // unpacking arguments by hand benchmarked faster
+      if (typeof offset === "undefined") offset = 0;
+      if (typeof offset !== "number") offset = 0;
+      var l = originalArgs.length, i = offset;
+      if (offset > l - 1) throw new Error("Offset greater than number of arguments.");
+      var args = new Array(l - 1);
+      for (; i < l; i++) args[i - offset] = originalArgs[i];
+      return args;
+    }
+
     function Registry() {
 
       var registry = this;
@@ -165,10 +187,7 @@ define(
       this.on = function(componentOn) {
         var instance = registry.findInstanceInfo(this), boundCallback;
 
-        // unpacking arguments by hand benchmarked faster
-        var l = arguments.length, i = 1;
-        var otherArgs = new Array(l - 1);
-        for (; i < l; i++) otherArgs[i - 1] = arguments[i];
+        var otherArgs = unpackArgs(arguments, 1);
 
         if (instance) {
           boundCallback = componentOn.apply(null, otherArgs);
@@ -180,15 +199,32 @@ define(
         }
       };
 
-      this.off = function(/*el, type, callback*/) {
-        var event = parseEventArgs(this, arguments),
+      this.off = function(componentOff /*, el, type, callback*/) {
+        var otherArgs = unpackArgs(arguments, 1);
+        var lastIndex = otherArgs.length - 1;
+
+        var event = parseEventArgs(this, otherArgs),
             instance = registry.findInstanceInfo(this);
 
+        // Find the events that have the correct unbound callback within *this instances*
+        // events, and then use the *bound*, which was what was registered with $.on,
+        // callback to turn it $.off.
+        // This is avoids the .guid messing that was going on before.
+        if (instance) {
+          var matchedEvents = findEventsByTarget(instance.events, event.callback);
+
+          var newArgs = otherArgs.slice(0, lastIndex);
+          for (var i = 0, e; e = matchedEvents[i]; i++) {
+            componentOff.apply(this, newArgs.concat([e.callback]));
+          }
+        }
+
+        // Remove the matching instance events (using the unbound callback)
         if (instance) {
           instance.removeBind(event);
         }
 
-        //remove from global event registry
+        // Remove from global event registry
         for (var i = 0, e; e = registry.events[i]; i++) {
           if (matchEvent(e, event)) {
             registry.events.splice(i, 1);
@@ -209,7 +245,7 @@ define(
         });
 
         this.around('on', registry.on);
-        this.after('off', registry.off);
+        this.around('off', registry.off);
         //debug tools may want to add advice to trigger
         window.DEBUG && DEBUG.enabled && this.after('trigger', registry.trigger);
         this.after('teardown', {obj: registry, fnName: 'teardown'});

--- a/test/spec/events_spec.js
+++ b/test/spec/events_spec.js
@@ -5,9 +5,11 @@ define(['lib/component'], function (defineComponent) {
   describe("(Core) events", function () {
     var Component = (function () {
       function testComponent() {
+        this.exampleMethod = jasmine.createSpy();
         this.after('initialize', function () {
           this.testString || (this.testString = "");
           this.testString += "-initBase-";
+          this.on(document, 'exampleDocumentEvent', this.exampleMethod);
         });
       }
 
@@ -33,12 +35,15 @@ define(['lib/component'], function (defineComponent) {
 
     beforeEach(function () {
       window.outerDiv = document.createElement('div');
+      window.anotherDiv = document.createElement('div');
       window.innerDiv = document.createElement('div');
       window.outerDiv.appendChild(window.innerDiv);
       document.body.appendChild(window.outerDiv);
+      document.body.appendChild(window.anotherDiv);
     });
     afterEach(function () {
       document.body.removeChild(window.outerDiv);
+      document.body.removeChild(window.anotherDiv);
       window.outerDiv = null;
       window.innerDiv = null;
       Component.teardownAll();
@@ -128,6 +133,14 @@ define(['lib/component'], function (defineComponent) {
       instance1.off(document, 'event1', spy);
       instance1.trigger('event2');
       expect(spy).toHaveBeenCalled();
+    });
+
+    it('does not unbind event handlers which share a node but were registered by different instances', function () {
+      var instance1 = (new Component).initialize(window.outerDiv);
+      var instance2 = (new Component).initialize(window.anotherDiv);
+      instance1.off(document, 'exampleDocumentEvent', instance1.exampleMethod);
+      instance1.trigger('exampleDocumentEvent');
+      expect(instance2.exampleMethod).toHaveBeenCalled();
     });
 
     it('bubbles custom events between components', function () {


### PR DESCRIPTION
Currently, in Flight, when you reuse a component multiple times, and those components all listen on one element (eg, document), when you this.off that event (in any of the component instances), it removes the handler for all the instances.

This means that tearing down any one of the repeated components, offs the events of the other instances, causing big problems.

This was becuase Flight was messing with guids to try to help jQuery figure out how to do $.off. As a result, it was modifying the one function that all instances of a particular component were referencing _and_ the bound version of this function such that _all_ bound copies of a function had the same guid.

jQuery uses the function's guid to figure out which event handlers to remove, so it was removing listeners that it shouldn't have been.

This was found because we repeat a column component in TweetDeck.

I didn't test, but I suspect this also affects different components that mix in the same mixin.

I put together a [test case that demonstrates this](https://github.com/phuu/flight-event-bug).
