### PR TITLE
Fixing IFramed application exceptions caused by window.localStorage in Flight

### DIFF
--- a/lib/debug.js
+++ b/lib/debug.js
@@ -94,16 +94,26 @@ define(
     }
 
     function saveLogFilter() {
-      if (window.localStorage) {
-        localStorage.setItem('logFilter_eventNames', logFilter.eventNames);
-        localStorage.setItem('logFilter_actions', logFilter.actions);
-      }
+      try {
+        if (window.localStorage) {
+          localStorage.setItem('logFilter_eventNames', logFilter.eventNames);
+          localStorage.setItem('logFilter_actions', logFilter.actions);
+        }
+      } catch (ignored) {};
     }
 
     function retrieveLogFilter() {
+      var eventNames, actions;
+      try {
+        eventNames = (window.localStorage && localStorage.getItem('logFilter_eventNames'));
+        actions = (window.localStorage && localStorage.getItem('logFilter_actions'));
+      } catch(ignored) {
+        eventNames = defaultEventNamesFilter;
+        actions = defaultActionsFilter;
+      }
       var result = {
-        eventNames: (window.localStorage && localStorage.getItem('logFilter_eventNames')) || defaultEventNamesFilter,
-        actions: (window.localStorage && localStorage.getItem('logFilter_actions')) || defaultActionsFilter
+        eventNames: eventNames,
+        actions: actions
       };
 
       // reconstitute arrays


### PR DESCRIPTION
Environment:
OSX Build 13C64
Chrome Version 33.0.1750.152
Flight version 1.0.9 (Can also replicate on 1.1.3)

Steps to reproduce:
- Open Chrome Inspector
- Disable Third Party Cookies in Chrome
- Visit http://nameless-retreat-3780.herokuapp.com/
- Click the "Development modal" button
- View the Chrome Inspector, you will see the exception

```
Uncaught SecurityError: Failed to read the 'localStorage' property from 'Window': Access is denied for this document.
```

This is quite a severe bug for us and I would appreciate feedback ASAP. Thanks.
