### PR TITLE
Enables event proxy from a specific node.

### DIFF
--- a/doc/base_api.md
+++ b/doc/base_api.md
@@ -133,6 +133,7 @@ Example of `handler` being a string that maps events to other events.
 This is useful for proxying browser events to more meaningful custom events.
 
 ```js
+this.on(document, 'dataSent', 'uiRefreshList');
 this.on('click', 'uiComponentClick');
 ```
 

--- a/lib/base.js
+++ b/lib/base.js
@@ -41,9 +41,9 @@ define(
       }
     }
 
-    function proxyEventTo(targetEvent) {
+    function proxyEventTo(targetEvent, instanceNode) {
       return function(e, data) {
-        $(e.target).trigger(targetEvent, data);
+        $(instanceNode || e.target).trigger(targetEvent, data);
       };
     }
 
@@ -106,7 +106,7 @@ define(
             this.resolveDelegateRules(origin)
           );
         } else if (typeof origin == 'string') {
-          originalCb = proxyEventTo(origin);
+          originalCb = proxyEventTo(origin, this.node);
         } else {
           originalCb = origin;
         }

--- a/test/spec/events_spec.js
+++ b/test/spec/events_spec.js
@@ -117,6 +117,22 @@ define(['lib/component', 'lib/registry'], function (defineComponent, registry) {
       expect(spy.mostRecentCall.args[1]).toEqual(data);
     });
 
+    it('proxy from one to another when declared using "on" with a string and a specific node', function () {
+      var instance = (new Component).initialize(window.outerDiv);
+      var data = {actor: 'Brent Spiner'};
+
+      // Declare an event proxy from 'sourceEvent' → 'targetEvent'
+      instance.on(document, 'sourceEvent', 'targetEvent');
+
+      var spy = jasmine.createSpy();
+      instance.on('targetEvent', spy);
+
+      $(document).trigger('sourceEvent', data);
+
+      expect(spy).toHaveBeenCalled();
+      expect(spy.mostRecentCall.args[1]).toEqual(data);
+    });
+
     it('proxy from one to another when declared using "on" with an object', function () {
       var instance = (new Component).initialize(window.outerDiv, {'innerDiv': 'div'});
       var data = {actor: 'Brent Spiner'};


### PR DESCRIPTION
This patch adds the functionality to specify a node when proxying browser events #232