### PR TITLE
Group console logs

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -73,6 +73,7 @@ define(
         payload && info.push(payload);
         info.push(elemToString(elem));
         info.push(component.constructor.describe.split(' ').slice(0,3).join(' '));
+        console.groupCollapsed && action == 'trigger' && console.groupCollapsed(action, name);
         console.info.apply(console, info);
       }
     }
@@ -81,6 +82,11 @@ define(
       this.before('trigger', function() {
         log('trigger', this, utils.toArray(arguments));
       });
+      if (console.groupCollapsed) {
+        this.after('trigger', function() {
+          console.groupEnd();
+        });
+      }
       this.before('on', function() {
         log('on', this, utils.toArray(arguments));
       });


### PR DESCRIPTION
Group the logs by triggers, making it easy to see nested events being fired.

eg,
![screen shot 2014-04-17 at 16 51 38](https://cloud.githubusercontent.com/assets/156496/2738272/4104bf96-c68b-11e3-9ca3-8415ecccb153.png)
