### PR TITLE
Edit advice example for regular objects

### DIFF
--- a/doc/advice_api.md
+++ b/doc/advice_api.md
@@ -112,11 +112,10 @@ define(function() {
 // import myObj and augment it
 define(function(require) {
   var advice = require('flight/lib/advice');
-  var compose = require('flight/lib/compose');
   var myObj = require('test/myObj');
 
   // add advice functions to myObj
-  compose.mixin(myObj, [advice.withAdvice]);
+  advice.withAdvice.call(myObj);
 
   // augment print function
   myObj.after('print', function() {


### PR DESCRIPTION
The example documentation for modules that use `advice` shouldn't have to explicitly require the `compose` component. The [specs](https://github.com/flightjs/flight/blob/master/test/spec/advice_spec.js#L86) have `advice` called directly on the object, which are how functional mixins should be invoked.
