### PR TITLE
Fixed spelling mistake in base_api.md

### DIFF
--- a/doc/base_api.md
+++ b/doc/base_api.md
@@ -212,7 +212,7 @@ Trigger an event.
 
 #### `selector`: String | Element | Element collection
 
-Optional. The DOM node(s) that the event will be disaptched to.
+Optional. The DOM node(s) that the event will be dispatched to.
 Defaults to the component instance's `node` value.
 
 #### `eventType`: String | Object


### PR DESCRIPTION
Replaced the word "disaptched" with "dispatched" inside of base_api.md
