### PR TITLE
Event data isn't passed to default event behaviour

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -141,7 +141,7 @@ define(
         $element.trigger((event || type), data);
 
         if (defaultFn && !event.isDefaultPrevented()) {
-          (this[defaultFn] || defaultFn).call(this);
+          (this[defaultFn] || defaultFn).call(this, event, data);
         }
 
         return $element;

--- a/test/spec/events_spec.js
+++ b/test/spec/events_spec.js
@@ -333,5 +333,19 @@ define(['lib/component', 'lib/registry'], function (defineComponent, registry) {
       expect(spy).not.toHaveBeenCalled();
     });
 
+    it('merges eventData into triggered default behavior event data', function () {
+      var instance = (new Component).initialize(document.body, { eventData: { penguins: 'cool', sheep: 'dull' } });
+      var data = { sheep: 'thrilling' };
+
+      var spy = jasmine.createSpy();
+      instance.trigger({ type: 'foo', defaultBehavior: spy }, data);
+      var args = spy.mostRecentCall.args;
+      var returnedData = args[1];
+      expect(returnedData.penguins).toBeDefined();
+      expect(returnedData.penguins).toBe('cool');
+      expect(returnedData.sheep).toBeDefined();
+      expect(returnedData.sheep).toBe('thrilling');
+    });
+
   });
 });


### PR DESCRIPTION
Example: http://codepen.io/6twenty/pen/jBwtD

When triggering an event using the object syntax (https://github.com/flightjs/flight/blob/master/doc/base_api.md#thistriggerselector-eventtype--eventpayload), the `data` object will **not** be passed to the function defined on the `defaultBehavior` property.

However, if you bind to this event, your bound function **will** receive the `data` object.

I believe the source of this issue is this line: https://github.com/flightjs/flight/blob/master/lib/base.js#L144

``` javascript
(this[defaultFn] || defaultFn).call(this);
```

Which can be changed to...

``` javascript
(this[defaultFn] || defaultFn).call(this, event, data);
```

...and the `defaultBehavior` function now receives the correct args. If the maintainers feel this is an acceptable fix, I'm happy to submit a pull request.
