### PR TITLE
Add the debug module into the standalone build

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,18 +10,20 @@ define(
     './advice',
     './component',
     './compose',
+    './debug',
     './logger',
     './registry',
     './utils'
   ],
 
-  function(advice, component, compose, logger, registry, utils) {
+  function(advice, component, compose, debug, logger, registry, utils) {
     'use strict';
 
     return {
       advice: advice,
       component: component,
       compose: compose,
+      debug: debug,
       logger: logger,
       registry: registry,
       utils: utils


### PR DESCRIPTION
This enables using the `debug` module with the standalone build. Debugging appears to work fine, though with one gotcha: you must manually set `window.DEBUG.enabled = true` even after calling `flight.debug.enable()`. So the final setup code needs to be something like this:

``` javascript
flight.debug.enable();
DEBUG.enabled = true;
DEBUG.events.logAll();
```

The `debug` module can then be activated by passing the `flight.logger` mixin into components.
