### PR TITLE
Updated .trigger() to parse the three argument case.

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -118,6 +118,10 @@ define(
         if (lastIndex == 1) {
           $element = $(arguments[0]);
           event = arguments[1];
+        } else if (lastIndex == 2) {
+          $element = $(arguments[0]);
+          event = arguments[1];
+          data = arguments[2];
         } else {
           $element = this.$node;
           event = arguments[0];

--- a/test/spec/events_spec.js
+++ b/test/spec/events_spec.js
@@ -249,6 +249,17 @@ define(['lib/component', 'lib/registry'], function (defineComponent, registry) {
       expect(spy).toHaveBeenCalled();
     });
 
+    it('can delegate the target of an event trigger', function () {
+      var instance1 = (new Component).initialize(window.innerDiv);
+      var instance2 = (new Component).initialize(window.outerDiv);
+      var someData = 'test data';
+
+      var spy = jasmine.createSpy();
+      instance2.on(document, 'click', spy);
+      instance1.trigger(document, 'click', someData);
+      expect(spy.mostRecentCall.args[1]).toEqual(someData);
+    });
+
     it('makes data and target element available to callback', function () {
       var instance = (new Component).initialize(document.body);
       var data = {blah: 'blah'};


### PR DESCRIPTION
https://github.com/flightjs/flight/blob/master/doc/base_api.md#thistriggerselector-eventtype--eventpayload
seems to indicate that passing three arguments into this.trigger(...) is
a supported case and should parse the arguments in the following order:
1. selector
2. eventType
3. eventPayload

However, I ran into issues when delegating the event trigger (e.g. to
the document object) with an event payload.

This commit includes a unit test exposing the problematic case and a
patch to base.js to properly parse the argument list for it.
