### PR TITLE
Adds contextSelector to attachTo and select

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -235,62 +235,78 @@ define(
         return rules;
       };
 
-    this.select = function(attributeKey) {
-      return this.$node.find(this.attr[attributeKey]);
-    };
+      this.select = function(attributeKey) {
+        var ctx, len, exist, el;
 
-    // New-style attributes
+        len = arguments.length;
+        exist = this.attr[arguments[0]] || this.attr[arguments[1]];
 
-    this.attributes = function(attrs) {
+        if (len !== 0 && len < 3 && exist) {
+          ctx = this.contextSelector || this.node;
+          if (len === 1) {
+            el = $(ctx).find(this.attr[arguments[0]]);
+          } else if (arguments[0].target) {
+            el = $(arguments[0].target).closest(ctx).find(this.attr[arguments[1]]);
+          } else {
+            el = arguments[0].closest(ctx).find(this.attr[arguments[1]]);
+          }
+        }
 
-      var Attributes = function() {};
+        return el || [];
+      };
 
-      if (this.attrDef) {
-        Attributes.prototype = new this.attrDef;
-      }
+      // New-style attributes
 
-      for (var name in attrs) {
-        Attributes.prototype[name] = attrs[name];
-      }
+      this.attributes = function(attrs) {
 
-      this.attrDef = Attributes;
-    };
+        var Attributes = function() {};
 
-    // Deprecated attributes
+        if (this.attrDef) {
+          Attributes.prototype = new this.attrDef;
+        }
 
-    this.defaultAttrs = function(defaults) {
-      utils.push(this.defaults, defaults, true) || (this.defaults = defaults);
-    };
+        for (var name in attrs) {
+          Attributes.prototype[name] = attrs[name];
+        }
 
-    this.initialize = function(node, attrs) {
-      attrs = attrs || {};
-      this.identity || (this.identity = componentId++);
+        this.attrDef = Attributes;
+      };
 
-      if (!node) {
-        throw new Error('Component needs a node');
-      }
+      // Deprecated attributes
 
-      if (node.jquery) {
-        this.node = node[0];
-        this.$node = node;
-      } else {
-        this.node = node;
-        this.$node = $(node);
-      }
+      this.defaultAttrs = function(defaults) {
+        utils.push(this.defaults, defaults, true) || (this.defaults = defaults);
+      };
 
-      if (this.attrDef) {
-        initAttributes.call(this, attrs);
-      } else {
-        initDeprecatedAttributes.call(this, attrs);
-      }
+      this.initialize = function(node, attrs) {
+        attrs = attrs || {};
+        this.identity || (this.identity = componentId++);
 
-      return this;
-    };
+        if (!node) {
+          throw new Error('Component needs a node');
+        }
 
-    this.teardown = function() {
-      teardownInstance(registry.findInstanceInfo(this));
-    };
-  }
+        if (node.jquery) {
+          this.node = node[0];
+          this.$node = node;
+        } else {
+          this.node = node;
+          this.$node = $(node);
+        }
+
+        if (this.attrDef) {
+          initAttributes.call(this, attrs);
+        } else {
+          initDeprecatedAttributes.call(this, attrs);
+        }
+
+        return this;
+      };
+
+      this.teardown = function() {
+        teardownInstance(registry.findInstanceInfo(this));
+      };
+    }
 
   return withBase;
 });

--- a/lib/component.js
+++ b/lib/component.js
@@ -46,27 +46,33 @@ define(
       }
     }
 
-    function attachTo(selector/*, options args */) {
-      // unpacking arguments by hand benchmarked faster
-      var l = arguments.length;
-      var args = new Array(l - 1);
-      for (var i = 1; i < l; i++) args[i - 1] = arguments[i];
+    function attachTo(selector/*, contextSelector, options */) {
+      var args, i, ii, arr, len, options, componentInfo, init;
 
       if (!selector) {
         throw new Error('Component needs to be attachTo\'d a jQuery object, native node or selector string');
       }
 
-      var options = utils.merge.apply(utils, args);
-      var componentInfo = registry.findComponentInfo(this);
+      args = arguments;
+      ii = (typeof args[1] === 'string') ? 2 : 1;
+      len = args.length
+      arr = new Array(len - ii);
+      for (i = ii; i < len; i++) arr[i - ii] = args[i];
 
-      $(selector).each(function(i, node) {
+      options = utils.merge.apply(utils, arr);
+      componentInfo = registry.findComponentInfo(this);
+      init = function(i, node) {
         if (componentInfo && componentInfo.isAttachedTo(node)) {
-          // already attached
           return;
         }
 
+        this.prototype.contextSelector = (typeof args[1] === 'string') ?
+          args[1] : null;
+
         (new this).initialize(node, options);
-      }.bind(this));
+      };
+
+      $(selector).each(init.bind(this));
     }
 
     function prettyPrintMixins() {

--- a/test/spec/instance_spec.js
+++ b/test/spec/instance_spec.js
@@ -127,6 +127,23 @@ define(['lib/component', 'lib/registry'], function (defineComponent, registry) {
         expect(c.attr.foo).toBe(46);
         expect(c.attr.bar).toBe(48);
       });
+
+      it('should be defined contextSelector using two arguments', function () {
+        var firstKey, c;
+        Component.attachTo('.test-node', 'div');
+        firstKey = Object.keys(registry.findComponentInfo(Component).instances)[0];
+        c = registry.findComponentInfo(Component).instances[firstKey].instance;
+        expect(c.contextSelector).toBe('div');
+      });
+
+      it('should be defined contextSelector and merge multiple options arguments correctly', function () {
+        Component.attachTo('.test-node', 'div', {foo: 46}, {bar: 48});
+        var firstKey = Object.keys(registry.findComponentInfo(Component).instances)[0];
+        var c = registry.findComponentInfo(Component).instances[firstKey].instance;
+        expect(c.contextSelector).toBe('div');
+        expect(c.attr.foo).toBe(46);
+        expect(c.attr.bar).toBe(48);
+      });
     });
   });
 


### PR DESCRIPTION
After participate in a discussion at the Flight's Google Group, "[Component granulation](https://groups.google.com/forum/#!msg/twitter-flight/BgAog5RW5us/was8OnMqiz4J)", I have developed a possible improvement to attachTo and the select method. Adding contextSelector as an argument to attachTo and using it as a string to get the closest selector.

The main goal is the posibility of delegate components to a main container. That means, less components to initialize and less events to listen.