### PR TITLE
Always call registry's trigger method from withRegistration

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -215,7 +215,7 @@ define(
         this.around('on', registry.on);
         this.after('off', registry.off);
         //debug tools may want to add advice to trigger
-        window.DEBUG && DEBUG.enabled && this.after('trigger', registry.trigger);
+        this.after('trigger', registry.trigger);
         this.after('teardown', {obj: registry, fnName: 'teardown'});
       };
 


### PR DESCRIPTION
This is to make it possible to add a runtime hook to trigger, even when the app is running out of debug mode (as TweetDeck does).

:rocket:
