### PR TITLE
Add style checker to `npm test`

### DIFF
--- a/.jscs.json
+++ b/.jscs.json
@@ -1,0 +1,35 @@
+{
+  "requireCurlyBraces": [
+    "if",
+    "else",
+    "for",
+    "while",
+    "do",
+    "try",
+    "catch"
+  ],
+  "disallowTrailingWhitespace": true,
+  "disallowTrailingComma": true,
+  "requireCapitalizedConstructors": true,    
+  "requireSpaceAfterKeywords": [
+    "if",
+    "else",
+    "for",
+    "while",
+    "do",
+    "switch",
+    "return",
+    "try",
+    "catch"
+  ],
+  "requireSpaceBeforeBinaryOperators": [
+    "=", "+=", "-=", "*=", "/=", "%=", "<<=", ">>=", ">>>=",
+    "&=", "|=", "^=", "+=",
+
+    "+", "-", "*", "/", "%", "<<", ">>", ">>>", "&",
+    "|", "^", "&&", "||", "===", "==", ">=",
+    "<=", "<", ">", "!=", "!=="
+  ],
+  "requireSpacesInConditionalExpression": true,
+  "requireSpaceBeforeBlockStatements": true
+}

--- a/jscs-pre-commit
+++ b/jscs-pre-commit
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Runs JSCS style checker using definitions in `.jscs.json` 
+# See https://github.com/mdevils/node-jscs for explanation of tests 
+#
+# to style check your JS
+# 1) ln -s ../../jscs-pre-commit .git/hooks/pre-commit
+# 2) npm install jscs -g
+
+# Adapted from an original script by Timothée Boucher
+# http://tech.adroll.com/blog/web/2014/03/05/adding-jscs-to-your-commit-hook.html  
+
+export JSCS_PATH=`which jscs`
+
+# Extract staged files to a temp directory
+TMPDIR=
+TMPFILE=
+if [ "$IS_LINUX" == "true" ]; then
+    TMPFILE=`mktemp jscs_tmp_XXXXXX`
+    TMPDIR=`mktemp -d jscs_tmp_XXXXXX`
+else
+    TMPFILE=`mktemp -t tmp/jscs_tmp_XXXXXX`
+    TMPDIR=`mktemp -t tmp/jscs_tmp -d`
+fi
+git diff --cached --name-only --diff-filter=ACMR | xargs git checkout-index --prefix=$TMPDIR/ --
+ 
+# Check JavaScript code style
+RUN_JSCS=1
+TOTAL_ERRORS=0
+PLURAL_SUFFIX= 
+ 
+JSFILES=$(git diff-index --name-status --cached HEAD | grep -v ^D | egrep '.js$' | cut -c3-)
+if [ -z "$JSFILES" ]; then
+    # No JavaScript file changed for this commit
+    RUN_JSCS=0
+elif [ -z "$JSCS_PATH" ]; then
+    echo -e "\033[0;31mIf you \033[1;34mnpm install jscs -g\033[0;31m I'll check your JS style\033[0;0m"
+    RUN_JSCS=0
+fi
+ 
+# Run JSCS
+if [ $RUN_JSCS -ne 0 ]; then
+    echo -e "\033[0;34mChecking JS style...\033[0;0m"
+    OUT=`$JSCS_PATH -r text $TMPDIR`
+    CODE=$?
+    # Erase last output line
+    # echo -ne '\r\033[K'
+    if [ $CODE -ne 0 ]; then
+        # Remove temp dir from output and color the filename
+        OUT=`echo "$OUT" | sed "s,$TMPDIR/\([^ ]*\),\`echo -e \"\033[0;34m\1\033[0m\"\`,"`
+        TOTAL_ERRORS=`echo -e "$OUT" | sed 's/[^0-9]//g' | tail -1`
+        # echo output minus last line
+        echo "$OUT" | sed '$ d'
+        if [ $TOTAL_ERRORS -ne 1 ]; then
+          PLURAL_SUFFIX="s"
+        fi 
+        echo -e "\033[0;31m$TOTAL_ERRORS code style error$PLURAL_SUFFIX found.\033[0;0m"
+        echo "Please fix and re-commit."
+        echo -e "Need to commit right away? commit with the \033[0;34m-n\033[0m flag"
+        rm -Rf $TMPDIR $TMPFILE
+        exit $CODE
+    else
+        echo -e "\033[0;32mNo JS code style errors found.\033[0;0m"
+    fi
+fi
+ 
+# Clean up
+rm -Rf $TMPDIR $TMPFILE
+

--- a/lib/advice.js
+++ b/lib/advice.js
@@ -20,8 +20,9 @@ define(
           // unpacking arguments by hand benchmarked faster
           var i = 0, l = arguments.length, args = new Array(l + 1);
           args[0] = base.bind(this);
-          for (; i < l; i++) args[i + 1] = arguments[i];
-
+          for (; i < l; i++) {
+            args[i + 1] = arguments[i];
+          }
           return wrapped.apply(this, args);
         };
       },

--- a/lib/base.js
+++ b/lib/base.js
@@ -19,7 +19,7 @@ define(
     // callback context is bound to component
     var componentId = 0;
 
-    function teardownInstance(instanceInfo){
+    function teardownInstance(instanceInfo) {
       instanceInfo.events.slice().forEach(function(event) {
         var args = [event.type];
 
@@ -33,7 +33,7 @@ define(
     function checkSerializable(type, data) {
       try {
         window.postMessage(data, '*');
-      } catch(e) {
+      } catch (e) {
         console.log('unserializable data for event',type,':',data);
         throw new Error(
           ['The event', type, 'on component', this.toString(), 'was triggered with non-serializable data'].join(' ')
@@ -47,7 +47,9 @@ define(
       this.attr = new this.attrDef;
 
       if (debug.enabled && window.console) {
-        for (var key in this.attrDef.prototype) definedKeys.push(key);
+        for (var key in this.attrDef.prototype) {
+          definedKeys.push(key);
+        }
         incomingKeys = Object.keys(attrs);
 
         for (var i = incomingKeys.length - 1; i >= 0; i--) {

--- a/lib/component.js
+++ b/lib/component.js
@@ -39,7 +39,9 @@ define(
       // unpacking arguments by hand benchmarked faster
       var l = arguments.length;
       var args = new Array(l - 1);
-      for (var i = 1; i < l; i++) args[i - 1] = arguments[i];
+      for (var i = 1; i < l; i++) {
+        args[i - 1] = arguments[i];
+      }
 
       if (!selector) {
         throw new Error('Component needs to be attachTo\'d a jQuery object, native node or selector string');
@@ -80,7 +82,9 @@ define(
       // unpacking arguments by hand benchmarked faster
       var l = arguments.length;
       var mixins = new Array(l);
-      for (var i = 0; i < l; i++) mixins[i] = arguments[i];
+      for (var i = 0; i < l; i++) {
+        mixins[i] = arguments[i];
+      }
 
       var Component = function() {};
 

--- a/lib/compose.js
+++ b/lib/compose.js
@@ -26,7 +26,7 @@ define(
     function mixin(base, mixins) {
       base.mixedIn = base.hasOwnProperty('mixedIn') ? base.mixedIn : [];
 
-      for (var i=0; i<mixins.length; i++) {
+      for (var i = 0; i < mixins.length; i++) {
         if (base.mixedIn.indexOf(mixins[i]) == -1) {
           setWritability(base, false);
           mixins[i].call(base);

--- a/lib/debug.js
+++ b/lib/debug.js
@@ -18,10 +18,10 @@ define(
     function traverse(util, searchTerm, options) {
       options = options || {};
       var obj = options.obj || window;
-      var path = options.path || ((obj==window) ? 'window' : '');
+      var path = options.path || ((obj == window) ? 'window' : '');
       var props = Object.keys(obj);
       props.forEach(function(prop) {
-        if ((tests[util] || util)(searchTerm, obj, prop)){
+        if ((tests[util] || util)(searchTerm, obj, prop)) {
           console.log([path, '.', prop].join(''), '->', ['(', typeof obj[prop], ')'].join(''), obj[prop]);
         }
         if (Object.prototype.toString.call(obj[prop]) == '[object Object]' && (obj[prop] != obj) && path.split('.').indexOf(prop) == -1) {
@@ -107,7 +107,7 @@ define(
       try {
         eventNames = (window.localStorage && localStorage.getItem('logFilter_eventNames'));
         actions = (window.localStorage && localStorage.getItem('logFilter_actions'));
-      } catch(ignored) {
+      } catch (ignored) {
         return;
       }
       eventNames && (logFilter.eventNames = eventNames);

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -27,10 +27,12 @@ define(
     }
 
     function log(action, component, eventArgs) {
-      if (!window.DEBUG || !window.DEBUG.enabled) return;
+      if (!window.DEBUG || !window.DEBUG.enabled) {
+        return;
+      }
       var name, eventType, elem, fn, payload, logFilter, toRegExp, actionLoggable, nameLoggable, info;
 
-      if (typeof eventArgs[eventArgs.length-1] == 'function') {
+      if (typeof eventArgs[eventArgs.length - 1] == 'function') {
         fn = eventArgs.pop();
         fn = fn.unbound || fn; // use unbound version if any (better info)
       }

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -172,12 +172,14 @@ define(
         // unpacking arguments by hand benchmarked faster
         var l = arguments.length, i = 1;
         var otherArgs = new Array(l - 1);
-        for (; i < l; i++) otherArgs[i - 1] = arguments[i];
+        for (; i < l; i++) {
+          otherArgs[i - 1] = arguments[i];
+        }
 
         if (instance) {
           boundCallback = componentOn.apply(null, otherArgs);
           if (boundCallback) {
-            otherArgs[otherArgs.length-1] = boundCallback;
+            otherArgs[otherArgs.length - 1] = boundCallback;
           }
           var event = parseEventArgs(this, otherArgs);
           instance.addBind(event);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -19,7 +19,7 @@ define(
         //IE8 getOwnPropertyDescriptor is built-in but throws exeption on non DOM objects
         try {
           Object.getOwnPropertyDescriptor(Object, 'keys');
-        } catch(e) {
+        } catch (e) {
          return false;
         }
       }
@@ -72,7 +72,9 @@ define(
           return {};
         }
 
-        for (var i=0; i < l; i++) args[i + 1] = arguments[i];
+        for (var i = 0; i < l; i++) {
+          args[i + 1] = arguments[i];
+        }
 
         //start with empty object so a copy is created
         args[0] = {};
@@ -138,7 +140,7 @@ define(
         return function() {
           var args = arguments;
 
-          for (var i = funcs.length-1; i >= 0; i--) {
+          for (var i = funcs.length - 1; i >= 0; i--) {
             args = [funcs[i].apply(this, args)];
           }
 
@@ -196,7 +198,7 @@ define(
         }
 
         var context, args, timeout, throttling, more, result;
-        var whenDone = this.debounce(function(){
+        var whenDone = this.debounce(function() {
           more = throttling = false;
         }, wait);
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "flight",
   "version": "1.2.0",
   "devDependencies": {
+    "jscs" : "^1.5.8",
     "karma": "~0.12.6",
     "karma-cli": "0.0.4",
     "karma-jasmine": "~0.1.0",
@@ -14,7 +15,9 @@
   },
   "scripts": {
     "build": "npm run webpack & npm run webpack-minified",
-    "test": "karma start --browsers Firefox --single-run",
+    "checkStyle": "jscs lib test",
+    "test": "npm run unit && npm run checkStyle",
+    "unit": "karma start --browsers Firefox --single-run",
     "watch": "karma start",
     "webpack": "webpack --progress --colors",
     "webpack-minified": "webpack --progress --colors --optimize-minimize --output-file flight.min.js"

--- a/test/spec/events_spec.js
+++ b/test/spec/events_spec.js
@@ -172,7 +172,7 @@ define(['lib/component', 'lib/registry'], function (defineComponent, registry) {
       var spy = jasmine.createSpy();
       instance1.on(document, 'event1', spy);
       var boundCb = registry.findInstanceInfo(instance1).events.filter(function(e) {
-        return e.type=="event1"
+        return e.type == "event1"
        })[0].callback;
       instance1.off(document, 'event1', boundCb);
       instance1.trigger('event1');
@@ -185,7 +185,7 @@ define(['lib/component', 'lib/registry'], function (defineComponent, registry) {
       instance1.on(document, 'event1', spy);
       instance1.on(document, 'event2', spy);
       var boundCb = registry.findInstanceInfo(instance1).events.filter(function(e) {
-        return e.type=="event1"
+        return e.type == "event1"
        })[0].callback;
       instance1.off(document, 'event1', boundCb);
       instance1.trigger('event2');
@@ -210,7 +210,7 @@ define(['lib/component', 'lib/registry'], function (defineComponent, registry) {
       var spy2 = jasmine.createSpy();
       instance1.on(document, 'event1', spy2);
       var boundCb = registry.findInstanceInfo(instance1).events.filter(function(e) {
-        return e.type=="event1"
+        return e.type == "event1"
       })[0].callback;
       instance1.off(document, 'event1', boundCb);
       instance1.trigger('event1');


### PR DESCRIPTION
Adding [JSCS](https://www.npmjs.org/package/jscs) with an initially [liberal style check](https://github.com/flightjs/flight/blob/4f610d2e75ac0fd9777795823b87abc3f01ecb27/.jscs.json) to npm test. This will run after the karma tests (including in Travis). The rules can be tightened later if agreed.

Fixed existing code conform to our initial JSCS rules.

I also added a [pre-commit hook](https://github.com/flightjs/flight/blob/4f610d2e75ac0fd9777795823b87abc3f01ecb27/jscs-pre-commit) but for some reason symlinking it to `.git/hooks` did not work - so you may have to copy it there manually
