### PR TITLE
Expose registry on DEBUG global

### DIFF
--- a/lib/debug.js
+++ b/lib/debug.js
@@ -2,9 +2,9 @@
 
 define(
 
-  [],
+  ['./registry'],
 
-  function() {
+  function(registry) {
     'use strict';
 
     // ==========================================
@@ -132,6 +132,8 @@ define(
 
         window.DEBUG = this;
       },
+
+      registry: registry,
 
       find: {
         byName: byName,


### PR DESCRIPTION
As per discussion, expose the registry on the DEBUG global so that debug tools can hook into it.
