### PR TITLE
Add support for multi-function advice

### DIFF
--- a/lib/advice.js
+++ b/lib/advice.js
@@ -45,17 +45,19 @@ define(
       withAdvice: function() {
         ['before', 'after', 'around'].forEach(function(m) {
           this[m] = function(method, fn) {
+            var methods = method.trim().split(' ');
 
-            utils.mutateProperty(this, method, function() {
-              if (typeof this[method] == 'function') {
-                this[method] = advice[m](this[method], fn);
-              } else {
-                this[method] = fn;
-              }
+            methods.forEach(function(i) {
+              utils.mutateProperty(this, i, function() {
+                if (typeof this[i] == 'function') {
+                  this[i] = advice[m](this[i], fn);
+                } else {
+                  this[i] = fn;
+                }
 
-              return this[method];
-            });
-
+                return this[i];
+              });
+            }, this);
           };
         }, this);
       }

--- a/test/spec/advice_spec.js
+++ b/test/spec/advice_spec.js
@@ -108,6 +108,46 @@ define(['lib/component', 'lib/advice'], function (defineComponent, advice) {
         subject.c();
         expect(subject.testc).toBe('|C!|');
       });
+
+      it('should add advice to multiple functions of an object at once', function () {
+        var subject = {
+          test: '',
+          a: function () {
+            this.test += 'A!';
+          },
+          b: function () {
+            this.test += 'B!';
+          },
+          c: function () {
+            this.test += 'C!';
+          }
+        }
+
+        advice.withAdvice.call(subject);
+
+        subject.before('a b', function () {
+          this.test += 'BEFORE!';
+        });
+
+        subject.after('b c', function () {
+          this.test += 'AFTER!';
+        });
+
+        subject.around('a b c', function (orig) {
+          this.test = '|';
+          orig.call(subject);
+          this.test += '|';
+        });
+
+        subject.a();
+        expect(subject.test).toBe('|BEFORE!A!|');
+
+        subject.b();
+        expect(subject.test).toBe('|BEFORE!B!AFTER!|');
+
+        subject.c();
+        expect(subject.test).toBe('|C!AFTER!|');
+      });
     });
 
   });


### PR DESCRIPTION
I just ran into this problem and realised the Advice API could be improved to intuitively allow specifying multiple methods at once. With my commit I can now write

```javascript
this.around('read write', function (func, key, value) {
  if (this.supportsLocalStorage) {
    return func(key, value);
  } 

  return false;
});
```

so that I'll have to make this check only once for both `read` and `write`.

The existing tests pass for me with this commit. If you find it useful I can go on to write another test for this use case.