### PR TITLE
Avoid unnecessary clearTimeouts in debounce()

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -177,7 +177,7 @@ define(
           };
           var callNow = immediate && !timeout;
 
-          clearTimeout(timeout);
+          timeout && clearTimeout(timeout);
           timeout = setTimeout(later, wait);
 
           if (callNow) {


### PR DESCRIPTION
debounce() used to return a function that when first invoked always called
`clearTimeout` before `setTimeout`, even if there was no timeout to clear.

This change adds a guard to prevent such unnecessary `clearTimeout` calls.
The performance implications are likely minimal, but the boolean check should
perform better in general than what amounts to a noop function call when
`timeout` is `null`. As well, devtools timelines will no longer display a
not-useful "Remove Timer" scripting blip for unnecessary `clearTimeout`s.
