### PR TITLE
Initial stab at attribute immutability

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -67,6 +67,11 @@ define(
           this.attr[key] = attrs[key];
         }
       }
+
+      if (debug.enabled) {
+        this.attr[key] = this.attr[key];
+        utils.propertyWritability(this.attr, key, false);
+      }
     }
 
     function initDeprecatedAttributes(attrs) {

--- a/test/spec/attribute_spec.js
+++ b/test/spec/attribute_spec.js
@@ -95,6 +95,20 @@ define(['lib/component', 'lib/debug'], function (defineComponent, debug) {
 
       TestComponent.teardownAll();
     });
+
+    it('throws an error if component attributes are overwritten', function() {
+      debug.enable(true);
+      var TestComponent = defineComponent(testComponentDefaultAttrs);
+      var instance = (new TestComponent).initialize(document.body);
+      expect(instance.attr.core).toBe(35);
+      expect(function() {
+        instance.attr.core = 57;
+      }).toThrow();
+      expect(instance.attr.core).toBe(35);
+      debug.enable(false);
+
+      TestComponent.teardownAll();
+    });
   });
 
   describe('(Core) this.defaultAttrs', function() {


### PR DESCRIPTION
Got this working end to end.  Implementation is a bit weird because if you want to lock the property you need to copy all the prototype inherited properties up to the top level in order to lock them predictably.

However, its a debug time only thing so Im not too worried about it.  Suggestions welcome though.  Im sure Im missing some details here.