### PR TITLE
Dynamic attribute setters

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -66,7 +66,12 @@ define(
         } else {
           this.attr[key] = attrs[key];
         }
+
+        if (typeof this.attr[key] == 'function') {
+          this.attr[key] = this.attr[key].call(this);
+        }
       }
+
     }
 
     function initDeprecatedAttributes(attrs) {

--- a/test/spec/attribute_spec.js
+++ b/test/spec/attribute_spec.js
@@ -23,6 +23,14 @@ define(['lib/component', 'lib/debug'], function (defineComponent, debug) {
       this.attributes({core: 1, extra: 38});
     }
 
+    function testComponentWithFunctionAttribute() {
+      this.attributes({
+        f: function() {
+          return this.node.nodeName.toLowerCase() == 'body';
+        }
+      });
+    }
+
     it('adds core defaults', function () {
       var TestComponent = defineComponent(testComponentDefaultAttrs);
       var instance = (new TestComponent).initialize(document.body);
@@ -92,6 +100,18 @@ define(['lib/component', 'lib/debug'], function (defineComponent, debug) {
       expect(instance.attr.core).toBe(1);
       expect(instance.attr.extra).toBe(38);
       debug.enable(false);
+
+      TestComponent.teardownAll();
+    });
+
+    it('will evaluate attributes that are functions at initialize time', function() {
+      var TestComponent = defineComponent(testComponentWithFunctionAttribute);
+
+      var instance = (new TestComponent).initialize(document.body);
+      expect(instance.attr.f).toBe(true);
+
+      var instance2 = (new TestComponent).initialize($('div').get(0));
+      expect(instance2.attr.f).toBe(false);
 
       TestComponent.teardownAll();
     });


### PR DESCRIPTION
Default or given attributes can be a function that gets evaluated at initialize time in the context of the component for dynamic attr setting.

``` javascript
this.attributes({ 
   href: function() {
    return this.$node.attr('href');
  }
});
```

but you can also do it at attach time:

``` javascript
Tweet.attachTo('.tweet', {
  tweetId: function() { return this.$node.data('tweet-id') }
});
```

SICK!
