### PR TITLE
console.info.apply fix for IE9

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -72,7 +72,8 @@ define(
         info.push(elemToString(elem));
         info.push(component.constructor.describe.split(' ').slice(0,3).join(' '));
         console.groupCollapsed && action == 'trigger' && console.groupCollapsed(action, name);
-        console.info.apply(console, info);
+        // IE9 doesn't define `apply` for console methods, but this works everywhere:
+        Function.prototype.apply.call(console.info, console, info);
       }
     }
 


### PR DESCRIPTION
Logging was breaking in IE9 because console.info.apply is undefined (even when dev tools is open and console.info is defined).  See: http://stackoverflow.com/questions/5538972/console-log-apply-not-working-in-ie9