### PR TITLE
Updated compose.js to allow mixing into a null-based object Fixes #225

### DIFF
--- a/lib/compose.js
+++ b/lib/compose.js
@@ -26,7 +26,7 @@ define(
     }
 
     function mixin(base, mixins) {
-      base.mixedIn = base.hasOwnProperty('mixedIn') ? base.mixedIn : [];
+      base.mixedIn = Object.prototype.hasOwnProperty.call(base, 'mixedIn') ? base.mixedIn : [];
 
       for (var i=0; i<mixins.length; i++) {
         if (base.mixedIn.indexOf(mixins[i]) == -1) {

--- a/test/spec/mixin_spec.js
+++ b/test/spec/mixin_spec.js
@@ -43,6 +43,16 @@ define(['lib/component', 'lib/utils', 'lib/compose'], function (defineComponent,
       expect(base.mixedInCount).toBe(2);
     });
 
+    it('should be able to mix into an object created from null', function () {
+      var mixMeIn = function () {
+        this.foo = 'bar';
+      };
+
+      var base = Object.create(null);
+      compose.mixin(base, [mixMeIn]);
+      expect(base.foo).toBe('bar');
+    });
+
   });
 
 });


### PR DESCRIPTION
I added a test case in the mixin spec to reproduce the case mentioned in the bug report and updated compose.js with the fix recommended by @angus-c.