### PR TITLE
Updated Base.js To keep the context in this.on([selector,] eventType, ha...

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -167,7 +167,7 @@ define(
         }
 
         if (lastIndex == 2) {
-          $element = $(arguments[0]);
+          $element = this.$node.find(arguments[0]);
           type = arguments[1];
         } else {
           $element = this.$node;


### PR DESCRIPTION
...ndler)

I've made a simple  adjustment so the components, mixins, aka our object keep their context closed. My motivation started trying to do recursive components ( such as nested tabs). Hope it helps, if test is needed I'll commit it again with no failing tests ;)