### PR TITLE
Rename define to defineComponent

### DIFF
--- a/lib/component.js
+++ b/lib/component.js
@@ -76,8 +76,8 @@ define(
 
     // define the constructor for a custom component type
     // takes an unlimited number of mixin functions as arguments
-    // typical api call with 3 mixins: define(timeline, withTweetCapability, withScrollCapability);
-    function define(/*mixins*/) {
+    // typical api call with 3 mixins: defineComponent(timeline, withTweetCapability, withScrollCapability);
+    function defineComponent(/*mixins*/) {
       // unpacking arguments by hand benchmarked faster
       var l = arguments.length;
       var mixins = new Array(l);
@@ -96,7 +96,7 @@ define(
       Component.attachTo = attachTo;
       // enables extension of existing "base" Components
       Component.mixin = function() {
-        var newComponent = define(); //TODO: fix pretty print
+        var newComponent = defineComponent(); //TODO: fix pretty print
         var newPrototype = Object.create(Component.prototype);
         newPrototype.mixedIn = [].concat(Component.prototype.mixedIn);
         newPrototype.defaults = utils.merge(Component.prototype.defaults);
@@ -118,13 +118,13 @@ define(
       return Component;
     }
 
-    define.teardownAll = function() {
+    defineComponent.teardownAll = function() {
       registry.components.slice().forEach(function(c) {
         c.component.teardownAll();
       });
       registry.reset();
     };
 
-    return define;
+    return defineComponent;
   }
 );


### PR DESCRIPTION
- Rename `define` to `defineComponent` in `component.js`

`component.js`'s internal `define` function can be mixed up with AMD's use of `define` as seen in the [amd-optimize](https://github.com/scalableminds/amd-optimize/pull/42) bug.

**Background**

I ran across an error when using [`amd-optimize`](https://github.com/scalableminds/amd-optimize) where it incorrectly thought that internal function called `define` was a request for AMD dependencies. I've [opened a PR there](https://github.com/scalableminds/amd-optimize/pull/42) but have not received word that it will be merged/considered.

My thought is that changing Flight will make it more flexible and not use the *"reserved word"* `define`.

Feedback welcomed.