### PR TITLE
Feature: debug.warn behaves like console.log

### DIFF
--- a/lib/debug.js
+++ b/lib/debug.js
@@ -133,10 +133,12 @@ define(
         window.DEBUG = this;
       },
 
-      warn: function (message) {
+      warn: function (/*messages*/) {
         if (!window.console) { return; }
         var fn = (console.warn || console.log);
-        fn.call(console, this.toString()  + ': ' + message);
+        var messages = [].slice.call(arguments);
+        messages.unshift(this.toString() + ':')
+        fn.apply(console, messages);
       },
 
       registry: registry,


### PR DESCRIPTION
Allows to pass comma delimited messages to debug.warn
This makes debugging a bit easier:

**No need to concatenate elements**

Instead of writing:
```javascript
DEBUG.warn('One' + ' two' + ' three');
```

Just write
```javascript
DEBUG.warn('One', 'two', 'three');
```

**Log JavaScript objects**

```javascript
DEBUG.warn('data:', data);
```