### PR TITLE
Remove jQuery dependency

### DIFF
--- a/doc/base_api.md
+++ b/doc/base_api.md
@@ -79,8 +79,7 @@ The `select` method takes an `attr` key as its argument. The value of the
 `attr` must be a CSS Selector. The method will return all matching elements
 within the component's `node`.
 
-This is a handy alternative to jQuery's `this.$node.find()` and prevents
-accidental access to elements outside of the component's `node`.
+This is a like jQuery's `find`, preventing accidental access to elements outside of the component's `node`.
 
 ```js
 this.attributes({
@@ -216,22 +215,6 @@ Defaults to the component instance's `node` value.
 #### `eventType`: String | Object
 
 String. The event type to be triggered.
-
-You can also specify a default function that will be called by the component,
-providing that nothing in the event's bubble chain invokes `preventDefault`.
-Default functions in custom events are analagous to the default actions of
-native events.
-
-To define a default function, make the `eventType` argument an object that
-specifies the event's `type` and a `defaultBehavior` property. A common use
-case is defining default behavior for keyboard events:
-
-```js
-this.trigger('#textInput', {
-  type: 'escapePressed',
-  defaultBehavior: this.blur
-});
-```
 
 #### `eventPayload`: Object
 

--- a/doc/component_api.md
+++ b/doc/component_api.md
@@ -114,16 +114,11 @@ they should only respond to events.
 ### Interacting with the DOM
 
 Once attached, Component instances have direct access to their node object via
-the `node` property. (There's also a jQuery version of the node available via
-the `$node` property.)
+the `node` property.
 
 ```js
 this.setId = function(n) {
   this.node.id = n;
-};
-
-this.hideComponent = function() {
-  this.$node.hide();
 };
 ```
 

--- a/doc/utils_api.md
+++ b/doc/utils_api.md
@@ -126,10 +126,9 @@ increment(); // sum will equal 1
 increment(); // sum will still equal 1
 ```
 
-Will only send one DELETE request to the server even if the click event is fired multiple times.
+Will only call the inner function even if the click event is fired multiple times.
 ```js
-var myHandler = function () {
-  $.ajax({type: 'DELETE', url: 'someurl.com', data: {id: 1}});
-};
-this.on('click', utils.once(myHandler));
+this.on('click', utils.once(function () {
+  // ...
+}));
 ```

--- a/lib/base.js
+++ b/lib/base.js
@@ -172,7 +172,7 @@ define(
         callback.target = originalCb;
         callback.context = this;
 
-        dom.addListener(element, type, callback);
+        dom.on(element, type, callback);
 
         // store every bound version of the callback
         originalCb.bound || (originalCb.bound = []);
@@ -210,13 +210,13 @@ define(
             }
           }, this);
 
-          dom.removeListener(element, type, callback);
+          dom.off(element, type, callback);
         } else {
           // Loop through the events of `this` instance
           // and unbind using the callback
           registry.findInstanceInfo(this).events.forEach(function (event) {
             if (type == event.type) {
-              dom.removeListener(element, type, event.callback);
+              dom.off(element, type, event.callback);
             }
           });
         }

--- a/lib/base.js
+++ b/lib/base.js
@@ -169,7 +169,7 @@ define(
                           '" because the given callback is not a function or an object');
         }
 
-        callback = originalCb.bind(this);
+        callback = dom.wrapCallback(originalCb, this);
         callback.target = originalCb;
         callback.context = this;
 

--- a/lib/base.js
+++ b/lib/base.js
@@ -116,8 +116,9 @@ define(
 
         // TODO not sure how to support defaultBehavior
         if (event.defaultBehavior) {
-          defaultFn = event.defaultBehavior;
-          event = $.Event(event.type);
+          throw Error('Not implemented.');
+          // defaultFn = event.defaultBehavior;
+          // event = $.Event(event.type);
         }
 
         type = event.type || event;
@@ -129,7 +130,8 @@ define(
 
         // Kill this bit
         if (typeof this.attr.eventData === 'object') {
-          data = $.extend(true, {}, this.attr.eventData, data);
+          throw Error('Not implemented.');
+          // data = $.extend(true, {}, this.attr.eventData, data);
         }
 
         dom.trigger(element, type, data);
@@ -138,7 +140,7 @@ define(
           (this[defaultFn] || defaultFn).call(this, event, data);
         }
 
-        return $element;
+        return element;
       };
 
 
@@ -147,6 +149,7 @@ define(
         var lastIndex = arguments.length - 1, origin = arguments[lastIndex];
 
         if (typeof origin == 'object') {
+          throw Error('Not implemented');
           //delegate callback
           originalCb = utils.delegate(
             this.resolveDelegateRules(origin)

--- a/lib/base.js
+++ b/lib/base.js
@@ -3,12 +3,13 @@
 define(
 
   [
+    './dom',
     './utils',
     './registry',
     './debug'
   ],
 
-  function(utils, registry, debug) {
+  function(dom, utils, registry, debug) {
     'use strict';
 
     // common mixin allocates basic functionality - used by all component prototypes
@@ -97,7 +98,7 @@ define(
       // of the event, or a hash specifying both the type
       // and a default function to be called.
       this.trigger = function() {
-        var $element, type, data, event, defaultFn;
+        var element, type, data, event, defaultFn;
         var lastIndex = arguments.length - 1, lastArg = arguments[lastIndex];
 
         if (typeof lastArg != 'string' && !(lastArg && lastArg.defaultBehavior)) {
@@ -106,29 +107,32 @@ define(
         }
 
         if (lastIndex == 1) {
-          $element = $(arguments[0]);
+          element = dom.select(arguments[0]);
           event = arguments[1];
         } else {
-          $element = this.$node;
+          element = this.node;
           event = arguments[0];
         }
 
+        // TODO not sure how to support defaultBehavior
         if (event.defaultBehavior) {
           defaultFn = event.defaultBehavior;
           event = $.Event(event.type);
         }
 
         type = event.type || event;
+        /////////////////////////////////
 
         if (debug.enabled && window.postMessage) {
           checkSerializable.call(this, type, data);
         }
 
-        if (typeof this.attr.eventData == 'object') {
+        // Kill this bit
+        if (typeof this.attr.eventData === 'object') {
           data = $.extend(true, {}, this.attr.eventData, data);
         }
 
-        $element.trigger((event || type), data);
+        dom.trigger(element, type, data);
 
         if (defaultFn && !event.isDefaultPrevented()) {
           (this[defaultFn] || defaultFn).call(this, event, data);
@@ -139,7 +143,7 @@ define(
 
 
       this.on = function() {
-        var $element, type, callback, originalCb;
+        var element, type, callback, originalCb;
         var lastIndex = arguments.length - 1, origin = arguments[lastIndex];
 
         if (typeof origin == 'object') {
@@ -152,10 +156,10 @@ define(
         }
 
         if (lastIndex == 2) {
-          $element = $(arguments[0]);
+          element = dom.select(arguments[0]);
           type = arguments[1];
         } else {
-          $element = this.$node;
+          element = this.node;
           type = arguments[0];
         }
 
@@ -168,7 +172,7 @@ define(
         callback.target = originalCb;
         callback.context = this;
 
-        $element.on(type, callback);
+        dom.addListener(element, type, callback);
 
         // store every bound version of the callback
         originalCb.bound || (originalCb.bound = []);
@@ -178,7 +182,7 @@ define(
       };
 
       this.off = function() {
-        var $element, type, callback;
+        var element, type, callback;
         var lastIndex = arguments.length - 1;
 
         if (typeof arguments[lastIndex] == 'function') {
@@ -187,10 +191,10 @@ define(
         }
 
         if (lastIndex == 1) {
-          $element = $(arguments[0]);
+          element = dom.select(arguments[0]);
           type = arguments[1];
         } else {
-          $element = this.$node;
+          element = this.node;
           type = arguments[0];
         }
 
@@ -205,18 +209,19 @@ define(
               return true;
             }
           }, this);
-          $element.off(type, callback);
+
+          dom.removeListener(element, type, callback);
         } else {
           // Loop through the events of `this` instance
           // and unbind using the callback
           registry.findInstanceInfo(this).events.forEach(function (event) {
             if (type == event.type) {
-              $element.off(type, event.callback);
+              dom.removeListener(element, type, event.callback);
             }
           });
         }
 
-        return $element;
+        return element;
       };
 
       this.resolveDelegateRules = function(ruleInfo) {
@@ -233,7 +238,7 @@ define(
       };
 
       this.select = function(attributeKey) {
-        return this.$node.find(this.attr[attributeKey]);
+        return dom.select(this.attr[attributeKey], this.node);
       };
 
       this.attributes = function(attrs) {
@@ -262,13 +267,7 @@ define(
           throw new Error('Component needs a node');
         }
 
-        if (node.jquery) {
-          this.node = node[0];
-          this.$node = node;
-        } else {
-          this.node = node;
-          this.$node = $(node);
-        }
+        this.node = dom.select(node);
 
         initAttributes.call(this, attrs);
 

--- a/lib/base.js
+++ b/lib/base.js
@@ -128,10 +128,8 @@ define(
           checkSerializable.call(this, type, data);
         }
 
-        // Kill this bit
         if (typeof this.attr.eventData === 'object') {
-          throw Error('Not implemented.');
-          // data = $.extend(true, {}, this.attr.eventData, data);
+          data = utils.merge(this.attr.eventData, data, true);
         }
 
         dom.trigger(element, type, data);

--- a/lib/base.js
+++ b/lib/base.js
@@ -146,22 +146,23 @@ define(
         var element, type, callback, originalCb;
         var lastIndex = arguments.length - 1, origin = arguments[lastIndex];
 
-        if (typeof origin == 'object') {
-          throw Error('Not implemented');
-          //delegate callback
-          originalCb = utils.delegate(
-            this.resolveDelegateRules(origin)
-          );
-        } else {
-          originalCb = origin;
-        }
-
         if (lastIndex == 2) {
           element = dom.select(arguments[0]);
           type = arguments[1];
         } else {
           element = this.node;
           type = arguments[0];
+        }
+
+        if (typeof origin == 'object') {
+          //delegate callback
+          originalCb = utils.delegate(
+            element,
+            this.resolveDelegateRules(origin),
+            dom
+          );
+        } else {
+          originalCb = origin;
         }
 
         if (typeof originalCb != 'function' && typeof originalCb != 'object') {

--- a/lib/base.js
+++ b/lib/base.js
@@ -92,16 +92,16 @@ define(
     function withBase() {
 
       // delegate trigger, bind and unbind to an element
-      // if $element not supplied, use component's node
+      // if element not supplied, use component's node
       // other arguments are passed on
       // event can be either a string specifying the type
       // of the event, or a hash specifying both the type
       // and a default function to be called.
       this.trigger = function() {
-        var element, type, data, event, defaultFn;
+        var element, type, data, event;
         var lastIndex = arguments.length - 1, lastArg = arguments[lastIndex];
 
-        if (typeof lastArg != 'string' && !(lastArg && lastArg.defaultBehavior)) {
+        if (typeof lastArg != 'string') {
           lastIndex--;
           data = lastArg;
         }
@@ -112,13 +112,6 @@ define(
         } else {
           element = this.node;
           event = arguments[0];
-        }
-
-        // TODO not sure how to support defaultBehavior
-        if (event.defaultBehavior) {
-          throw Error('Not implemented.');
-          // defaultFn = event.defaultBehavior;
-          // event = $.Event(event.type);
         }
 
         type = event.type || event;
@@ -133,10 +126,6 @@ define(
         }
 
         dom.trigger(element, type, data);
-
-        if (defaultFn && !event.isDefaultPrevented()) {
-          (this[defaultFn] || defaultFn).call(this, event, data);
-        }
 
         return element;
       };

--- a/lib/base.js
+++ b/lib/base.js
@@ -170,6 +170,7 @@ define(
                           '" because the given callback is not a function or an object');
         }
 
+        // Create a callback that lifts the DOM event into some custom type
         callback = dom.wrapCallback(originalCb, this);
         callback.target = originalCb;
         callback.context = this;

--- a/lib/component.js
+++ b/lib/component.js
@@ -3,6 +3,7 @@
 define(
 
   [
+    './dom',
     './advice',
     './utils',
     './compose',
@@ -12,7 +13,7 @@ define(
     './debug'
   ],
 
-  function(advice, utils, compose, withBase, registry, withLogging, debug) {
+  function(dom, advice, utils, compose, withBase, registry, withLogging, debug) {
     'use strict';
 
     var functionNameRegEx = /function (.*?)\s?\(/;
@@ -50,7 +51,9 @@ define(
       var options = utils.merge.apply(utils, args);
       var componentInfo = registry.findComponentInfo(this);
 
-      $(selector).each(function(i, node) {
+
+      // how do we accomodate jquery each vs forEach?
+      dom.select(selector).forEach(function(node) {
         if (componentInfo && componentInfo.isAttachedTo(node)) {
           // already attached
           return;

--- a/lib/component.js
+++ b/lib/component.js
@@ -51,9 +51,7 @@ define(
       var options = utils.merge.apply(utils, args);
       var componentInfo = registry.findComponentInfo(this);
 
-
-      // how do we accomodate jquery each vs forEach?
-      dom.select(selector).forEach(function(node) {
+      dom.selectAll(selector).forEach(function(node) {
         if (componentInfo && componentInfo.isAttachedTo(node)) {
           // already attached
           return;

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -57,6 +57,10 @@ define(function() {
             overrideSet = true;
           }
         });
+
+        if (this.detail === null) {
+          this.detail = undefined;
+        }
       }, this);
     }
 

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -15,22 +15,48 @@ define(function() {
         writable: true
       });
 
-      ['bubbles', 'cancelable', 'currentTarget',
-       'detail', 'eventPhase', 'defaultPrevented',
-       'isTrusted', 'target', 'timeStamp', 'type'].forEach(function (k) {
-          var override;
-          var overrideSet = false;
-          Object.defineProperty(this, k, {
-            configurable: true,
-            enumerable: true,
-            get: function () {
-              return (overrideSet ? override : this.nativeEvent[k]);
-            },
-            set: function (v) {
-              override = v;
-              overrideSet = true;
-            }
-          });
+      var eventKeys = [
+        'bubbles', 'cancelable', 'currentTarget',
+        'detail', 'eventPhase', 'defaultPrevented',
+        'isTrusted', 'target', 'timeStamp', 'type',
+        // clipboard events
+        'clipboardData',
+        // keyboard events
+        'altKey', 'charCode', 'ctrlKey', 'key',
+        'keyCode', 'locale', 'location', 'metaKey',
+        'repeat', 'shiftKey', 'which',
+        // focus events
+        'relatedTarget',
+        // mouse events
+        'altKey', 'button', 'buttons', 'clientX', 'clientY',
+        'ctrlKey', 'metaKey', 'pageX', 'pageY', 'relatedTarget',
+        'screenX', 'screenY', 'shiftKey',
+        // touch events
+        'altKey', 'changedTouches', 'ctrlKey', 'metaKey',
+        'shiftKey', 'targetTouches', 'touches',
+        // ui events
+        'view',
+        // wheel events
+        'deltaMode', 'deltaX', 'deltaY', 'deltaZ'
+      ];
+
+      eventKeys.forEach(function (k) {
+        if (typeof this.nativeEvent[k] === 'undefined') {
+          return;
+        }
+        var override;
+        var overrideSet = false;
+        Object.defineProperty(this, k, {
+          configurable: true,
+          enumerable: true,
+          get: function () {
+            return (overrideSet ? override : this.nativeEvent[k]);
+          },
+          set: function (v) {
+            override = v;
+            overrideSet = true;
+          }
+        });
       }, this);
     }
 

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -75,6 +75,11 @@ define(function() {
   }
 
   function normalizeTypeArgument(type) {
+    // Handle 'event object'
+    if (typeof type === 'object') {
+      type = type.type;
+    }
+
     if (typeof type !== 'string') {
       throw new Error('Event type is not a string');
     }

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -3,6 +3,52 @@
 define(function() {
   'use strict';
 
+  function FlightEvent(nativeEvent) {
+    Object.defineProperty(this, 'nativeEvent', {
+      value: nativeEvent
+    });
+
+    Object.defineProperty(this, 'propagationStopped', {
+      value: false,
+      enumerable: false,
+      writable: true
+    });
+
+    ['bubbles', 'cancelable', 'currentTarget',
+     'detail', 'eventPhase', 'defaultPrevented',
+     'isTrusted', 'target', 'timeStamp', 'type'].forEach(function (k) {
+        var override;
+        var overrideSet = false;
+        Object.defineProperty(this, k, {
+          configurable: true,
+          enumerable: true,
+          get: function () {
+            return (overrideSet ? override : this.nativeEvent[k]);
+          },
+          set: function (v) {
+            override = v;
+            overrideSet = true;
+          }
+        });
+    }, this);
+  }
+
+
+  ['stopPropagation'].forEach(function (k) {
+    FlightEvent.prototype[k] = function () {
+      this.nativeEvent[k].apply(this.nativeEvent, arguments);
+    };
+  });
+
+  FlightEvent.prototype.stopPropagation = function () {
+    this.propagationStopped = true;
+    return this.nativeEvent.stopPropagation.apply(this.nativeEvent, arguments);
+  };
+
+  FlightEvent.prototype.isPropagationStopped = function () {
+    return this.propagationStopped;
+  };
+
   function select(selector) {
     if (typeof selector === 'undefined' || selector === null) {
       throw new Error('Undefined or null selector passed to dom.select');
@@ -25,7 +71,8 @@ define(function() {
     throw new Error('Cannot use given selector');
   }
 
-  function selectAll(selector) {
+  function selectAll(selector, context) {
+    context = context || document;
     if (typeof selector === 'undefined' || selector === null) {
       throw new Error('Undefined or null selector passed to dom.select');
     }
@@ -33,7 +80,7 @@ define(function() {
     // CSS Selector
     if (typeof selector === 'string') {
       return [].slice.call(
-        document.querySelectorAll(selector)
+        context.querySelectorAll(selector)
       );
     }
 
@@ -135,9 +182,31 @@ define(function() {
   }
 
   function wrapCallback(callback, ctx) {
-    return function wrappedCallback(event) {
+    return function wrappedCallback(nativeEvent) {
+        var event = new FlightEvent(nativeEvent);
         return callback.call(ctx, event, event.detail);
       };
+  }
+
+  function parents(node) {
+    if (!node.parentNode) {
+      return [];
+    }
+    return [node.parentNode].concat(parents(node.parentNode));
+  }
+
+  function closest(contextElement, target, selector) {
+    var matchingElements = selectAll(selector, contextElement);
+    if (matchingElements.indexOf(target) > -1) {
+      return target;
+    }
+    var targetParents = parents(target);
+    return matchingElements.reduce(function (found, matchingElement) {
+      if (!found && targetParents.indexOf(matchingElement) > -1) {
+        return matchingElement;
+      }
+      return found;
+    }, undefined);
   }
 
   return {
@@ -146,7 +215,9 @@ define(function() {
     on: on,
     off: off,
     trigger: trigger,
-    wrapCallback: wrapCallback
+    wrapCallback: wrapCallback,
+    closest: closest,
+    FlightEvent: FlightEvent
   };
 
 });

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -10,6 +10,10 @@ define(function(require) {
 
     // CSS Selector
     if (typeof selector === 'string') {
+      if (selector === 'document') {
+        return document.documentElement;
+      }
+
       return document.querySelector(selector);
     }
 
@@ -28,7 +32,9 @@ define(function(require) {
 
     // CSS Selector
     if (typeof selector === 'string') {
-      return document.querySelectorAll(selector);
+      return [].slice.call(
+        document.querySelectorAll(selector)
+      );
     }
 
     // Element
@@ -38,7 +44,7 @@ define(function(require) {
 
     // Nodelist
     if ('length' in selector) {
-      return selector;
+      return [].slice.call(selector);
     }
 
     throw new Error('Cannot use given selector');
@@ -124,6 +130,7 @@ define(function(require) {
 
   return {
     select: select,
+    selectAll: selectAll,
     on: on,
     off: off,
     trigger: trigger

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -118,6 +118,10 @@ define(function() {
 
     // CSS Selector
     if (typeof selector === 'string') {
+      if (selector === 'document') {
+        return [select(selector)];
+      }
+
       return [].slice.call(
         context.querySelectorAll(selector)
       );

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -3,51 +3,59 @@
 define(function() {
   'use strict';
 
-  function FlightEvent(nativeEvent) {
-    Object.defineProperty(this, 'nativeEvent', {
-      value: nativeEvent
-    });
+  var FlightEvent = (function () {
+    function FlightEvent(nativeEvent) {
+      Object.defineProperty(this, 'nativeEvent', {
+        value: nativeEvent
+      });
 
-    Object.defineProperty(this, 'propagationStopped', {
-      value: false,
-      enumerable: false,
-      writable: true
-    });
+      Object.defineProperty(this, 'propagationStopped', {
+        value: false,
+        enumerable: false,
+        writable: true
+      });
 
-    ['bubbles', 'cancelable', 'currentTarget',
-     'detail', 'eventPhase', 'defaultPrevented',
-     'isTrusted', 'target', 'timeStamp', 'type'].forEach(function (k) {
-        var override;
-        var overrideSet = false;
-        Object.defineProperty(this, k, {
-          configurable: true,
-          enumerable: true,
-          get: function () {
-            return (overrideSet ? override : this.nativeEvent[k]);
-          },
-          set: function (v) {
-            override = v;
-            overrideSet = true;
-          }
-        });
-    }, this);
-  }
+      ['bubbles', 'cancelable', 'currentTarget',
+       'detail', 'eventPhase', 'defaultPrevented',
+       'isTrusted', 'target', 'timeStamp', 'type'].forEach(function (k) {
+          var override;
+          var overrideSet = false;
+          Object.defineProperty(this, k, {
+            configurable: true,
+            enumerable: true,
+            get: function () {
+              return (overrideSet ? override : this.nativeEvent[k]);
+            },
+            set: function (v) {
+              override = v;
+              overrideSet = true;
+            }
+          });
+      }, this);
+    }
 
-
-  ['stopPropagation'].forEach(function (k) {
-    FlightEvent.prototype[k] = function () {
-      this.nativeEvent[k].apply(this.nativeEvent, arguments);
+    var hooks = {
+      'stopPropagation': function () {
+        this.propagationStopped = true;
+      }
     };
-  });
 
-  FlightEvent.prototype.stopPropagation = function () {
-    this.propagationStopped = true;
-    return this.nativeEvent.stopPropagation.apply(this.nativeEvent, arguments);
-  };
+    ['preventDefault', 'stopPropagation'].forEach(function (k) {
+      FlightEvent.prototype[k] = function () {
+        if (hooks[k]) {
+          hooks[k].apply(this, arguments);
+        }
+        this.nativeEvent[k].apply(this.nativeEvent, arguments);
+      };
+    });
 
-  FlightEvent.prototype.isPropagationStopped = function () {
-    return this.propagationStopped;
-  };
+    FlightEvent.prototype.isPropagationStopped = function () {
+      return this.propagationStopped;
+    };
+
+    return FlightEvent;
+
+  }());
 
   function select(selector) {
     if (typeof selector === 'undefined' || selector === null) {
@@ -146,7 +154,6 @@ define(function() {
     var elements = normalizeElementArgument(elementsOrSelector);
     var eventType = normalizeTypeArgument(type);
     callback = normalizeCallbackArgument(callback);
-    var ctx = this;
 
     return elements.map(function (element) {
       element.addEventListener(eventType, callback);

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -87,7 +87,8 @@ define(function() {
 
   }());
 
-  function select(selector) {
+  function select(selector, context) {
+    context = context || document;
     if (typeof selector === 'undefined' || selector === null) {
       throw new Error('Undefined or null selector passed to dom.select');
     }
@@ -98,7 +99,7 @@ define(function() {
         return document.documentElement;
       }
 
-      return document.querySelector(selector);
+      return context.querySelector(selector);
     }
 
     // Element

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1,6 +1,6 @@
 /* Copyright 2013 Twitter, Inc. Licensed under The MIT License. http://opensource.org/licenses/MIT */
 
-define(function(require) {
+define(function() {
   'use strict';
 
   function select(selector) {
@@ -101,7 +101,7 @@ define(function(require) {
     };
 
     return elements.map(function (element) {
-      element.addEventListener(type, wrappedCallback);
+      element.addEventListener(eventType, wrappedCallback);
       return wrappedCallback;
     });
   }
@@ -112,7 +112,7 @@ define(function(require) {
     var callback = normalizeCallbackArgument(callback);
 
     return elements.map(function (element) {
-      element.removeEventListener(type, callback);
+      element.removeEventListener(eventType, callback);
       return element;
     });
   }

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -98,23 +98,19 @@ define(function() {
   function on(elementsOrSelector, type, callback) {
     var elements = normalizeElementArgument(elementsOrSelector);
     var eventType = normalizeTypeArgument(type);
-    var callback = normalizeCallbackArgument(callback);
+    callback = normalizeCallbackArgument(callback);
     var ctx = this;
 
-    var wrappedCallback = function (event) {
-      return callback.call(ctx, event, event.detail);
-    };
-
     return elements.map(function (element) {
-      element.addEventListener(eventType, wrappedCallback);
-      return wrappedCallback;
+      element.addEventListener(eventType, callback);
+      return callback;
     });
   }
 
   function off(elementsOrSelector, type, callback) {
     var elements = normalizeElementArgument(elementsOrSelector);
     var eventType = normalizeTypeArgument(type);
-    var callback = normalizeCallbackArgument(callback);
+    callback = normalizeCallbackArgument(callback);
 
     return elements.map(function (element) {
       element.removeEventListener(eventType, callback);
@@ -138,12 +134,19 @@ define(function() {
     });
   }
 
+  function wrapCallback(callback, ctx) {
+    return function wrappedCallback(event) {
+        return callback.call(ctx, event, event.detail);
+      };
+  }
+
   return {
     select: select,
     selectAll: selectAll,
     on: on,
     off: off,
-    trigger: trigger
+    trigger: trigger,
+    wrapCallback: wrapCallback
   };
 
 });

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1,0 +1,132 @@
+/* Copyright 2013 Twitter, Inc. Licensed under The MIT License. http://opensource.org/licenses/MIT */
+
+define(function(require) {
+  'use strict';
+
+  function select(selector) {
+    if (typeof selector === 'undefined' || selector === null) {
+      throw new Error('Undefined or null selector passed to dom.select');
+    }
+
+    // CSS Selector
+    if (typeof selector === 'string') {
+      return document.querySelector(selector);
+    }
+
+    // Element
+    if (selector.nodeType) {
+      return selector;
+    }
+
+    throw new Error('Cannot use given selector');
+  }
+
+  function selectAll(selector) {
+    if (typeof selector === 'undefined' || selector === null) {
+      throw new Error('Undefined or null selector passed to dom.select');
+    }
+
+    // CSS Selector
+    if (typeof selector === 'string') {
+      return document.querySelectorAll(selector);
+    }
+
+    // Element
+    if (selector.nodeType) {
+      return [selector];
+    }
+
+    // Nodelist
+    if ('length' in selector) {
+      return selector;
+    }
+
+    throw new Error('Cannot use given selector');
+  }
+
+  function normalizeElementArgument(elementsOrSelector) {
+    // Useless argument
+    if (!elementsOrSelector) {
+      throw new Error('Unknown element or selector');
+    }
+
+    // Selector passed as first argument
+    if (typeof elementsOrSelector === 'string') {
+      elementsOrSelector = selectAll(elementsOrSelector);
+    }
+
+    // Convert NodeList to array
+    if ('length' in elementsOrSelector) {
+      elementsOrSelector = [].slice.call(elementsOrSelector);
+    }
+
+    // Convert single Node to array
+    if (!('length' in elementsOrSelector)) {
+      elementsOrSelector = [elementsOrSelector];
+    }
+
+    return elementsOrSelector;
+  }
+
+  function normalizeTypeArgument(type) {
+    if (typeof type !== 'string') {
+      throw new Error('Event type is not a string');
+    }
+
+    return '' + type;
+  }
+
+  function normalizeCallbackArgument(callback) {
+    if (typeof callback !== 'function') {
+      throw new Error('Callback is not a function');
+    }
+
+    return callback;
+  }
+
+  function on(elementsOrSelector, type, callback) {
+    var elements = normalizeElementArgument(elementsOrSelector);
+    var eventType = normalizeTypeArgument(type);
+    var callback = normalizeCallbackArgument(callback);
+
+    return elements.map(function (element) {
+      element.addEventListener(type, callback);
+      return element;
+    });
+  }
+
+  function off(elementsOrSelector, type, callback) {
+    var elements = normalizeElementArgument(elementsOrSelector);
+    var eventType = normalizeTypeArgument(type);
+    var callback = normalizeCallbackArgument(callback);
+
+    return elements.map(function (element) {
+      element.removeEventListener(type, callback);
+      return element;
+    });
+  }
+
+  function trigger(elementsOrSelector, type, data) {
+    var elements = normalizeElementArgument(elementsOrSelector);
+    var eventType = normalizeTypeArgument(type);
+
+    return elements.map(function (element) {
+      element.dispatchEvent(
+          new CustomEvent(eventType, {
+              detail: data,
+              bubbles: true,
+              cancelable: true
+          })
+      );
+      return element;
+    });
+  }
+
+  return {
+    select: select,
+    on: on,
+    off: off,
+    trigger: trigger
+  };
+
+});

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -94,10 +94,15 @@ define(function(require) {
     var elements = normalizeElementArgument(elementsOrSelector);
     var eventType = normalizeTypeArgument(type);
     var callback = normalizeCallbackArgument(callback);
+    var ctx = this;
+
+    var wrappedCallback = function (event) {
+      return callback.call(ctx, event, event.detail);
+    };
 
     return elements.map(function (element) {
-      element.addEventListener(type, callback);
-      return element;
+      element.addEventListener(type, wrappedCallback);
+      return wrappedCallback;
     });
   }
 

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -213,21 +213,23 @@ define(function() {
 
     return elements.map(function (element) {
       element.dispatchEvent(
-          new CustomEvent(eventType, {
-              detail: data,
-              bubbles: true,
-              cancelable: true
-          })
+        new CustomEvent(eventType, {
+          detail: data,
+          bubbles: true,
+          cancelable: true
+        })
       );
       return element;
     });
   }
 
+  // Create a callback that lifts the DOM event into a FlightEvent, so we can detect when
+  // propagation has been stopped.
   function wrapCallback(callback, ctx) {
     return function wrappedCallback(nativeEvent) {
-        var event = new FlightEvent(nativeEvent);
-        return callback.call(ctx, event, event.detail);
-      };
+      var event = new FlightEvent(nativeEvent);
+      return callback.call(ctx, event, event.detail);
+    };
   }
 
   function parents(node) {

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -4,9 +4,9 @@ define(function() {
   'use strict';
 
   var FlightEvent = (function () {
-    function FlightEvent(nativeEvent) {
-      Object.defineProperty(this, 'nativeEvent', {
-        value: nativeEvent
+    function FlightEvent(originalEvent) {
+      Object.defineProperty(this, 'originalEvent', {
+        value: originalEvent
       });
 
       Object.defineProperty(this, 'propagationStopped', {
@@ -41,7 +41,7 @@ define(function() {
       ];
 
       eventKeys.forEach(function (k) {
-        if (typeof this.nativeEvent[k] === 'undefined') {
+        if (typeof this.originalEvent[k] === 'undefined') {
           return;
         }
         var override;
@@ -50,22 +50,22 @@ define(function() {
           configurable: true,
           enumerable: true,
           get: function () {
-            return (overrideSet ? override : this.nativeEvent[k]);
+            return (overrideSet ? override : this.originalEvent[k]);
           },
           set: function (v) {
             override = v;
             overrideSet = true;
           }
         });
-
-        if (this.detail === null) {
-          this.detail = undefined;
-        }
       }, this);
+
+      if (this.detail === null) {
+        this.detail = undefined;
+      }
     }
 
     var hooks = {
-      'stopPropagation': function () {
+      stopPropagation: function () {
         this.propagationStopped = true;
       }
     };
@@ -75,7 +75,7 @@ define(function() {
         if (hooks[k]) {
           hooks[k].apply(this, arguments);
         }
-        this.nativeEvent[k].apply(this.nativeEvent, arguments);
+        return this.originalEvent[k].apply(this.originalEvent, arguments);
       };
     });
 
@@ -226,8 +226,8 @@ define(function() {
   // Create a callback that lifts the DOM event into a FlightEvent, so we can detect when
   // propagation has been stopped.
   function wrapCallback(callback, ctx) {
-    return function wrappedCallback(nativeEvent) {
-      var event = new FlightEvent(nativeEvent);
+    return function wrappedCallback(originalEvent) {
+      var event = new FlightEvent(originalEvent);
       return callback.call(ctx, event, event.detail);
     };
   }

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -238,17 +238,28 @@ define(function() {
   }
 
   function closest(contextElement, target, selector) {
+    // Find all the matching elements within the context
     var matchingElements = selectAll(selector, contextElement);
+    // Is the node that the event was fired on the node we're looking for?
     if (matchingElements.indexOf(target) > -1) {
       return target;
     }
+    // Otherwise, we have to walk back up the DOM.
+    // First, gather all the parents of the target.
     var targetParents = parents(target);
-    return matchingElements.reduce(function (found, matchingElement) {
-      if (!found && targetParents.indexOf(matchingElement) > -1) {
-        return matchingElement;
+    // Using the selector-matching elements, look to see if any of the parents match. This is
+    // bounded to within the contextElement because the matchingElements only come from within that
+    // node. Imperitive loop here because we can't guarantee Array#find.
+    var match;
+    var i = 0;
+    var l = matchingElements.length;
+    for (; i < l; i++) {
+      if (targetParents.indexOf(matchingElements[i]) > -1) {
+        match = matchingElements[i];
+        break;
       }
-      return found;
-    }, undefined);
+    }
+    return match;
   }
 
   return {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -35,11 +35,11 @@ define(
       }
 
       if (eventArgs.length == 1) {
-        elem = component.$node[0];
+        elem = component.node;
         eventType = eventArgs[0];
       } else if ((eventArgs.length == 2) && typeof eventArgs[1] == 'object' && !eventArgs[1].type) {
         //2 args, first arg is not elem
-        elem = component.$node[0];
+        elem = component.node;
         eventType = eventArgs[0];
         if (action == "trigger") {
           payload = eventArgs[1];

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -259,16 +259,16 @@ define(
         };
       },
 
-      delegate: function(rules) {
-        return function(e, data) {
-          // how do we do closest?
-          var target = $(e.target), parent;
+      delegate: function(contextElement, rules, dom) {
+        return function(event, data) {
+          var target = event.target;
 
           Object.keys(rules).forEach(function(selector) {
-            if (!e.isPropagationStopped() && (parent = target.closest(selector)).length) {
+            var parent = dom.closest(contextElement, target, selector);
+            if (!event.isPropagationStopped() && parent) {
               data = data || {};
-              e.currentTarget = data.el = parent[0];
-              return rules[selector].apply(this, [e, data]);
+              event.currentTarget = (data.el = parent);
+              return rules[selector].apply(this, [event, data]);
             }
           }, this);
         };
@@ -310,19 +310,16 @@ define(
 
       // Property locking/unlocking
       mutateProperty: function(obj, prop, op) {
-        var writable;
-
         if (!canWriteProtect() || !obj.hasOwnProperty(prop)) {
           op.call(obj);
           return;
         }
 
-        writable = Object.getOwnPropertyDescriptor(obj, prop).writable;
+        var writable = Object.getOwnPropertyDescriptor(obj, prop).writable;
 
         Object.defineProperty(obj, prop, { writable: true });
         op.call(obj);
         Object.defineProperty(obj, prop, { writable: writable });
-
       }
 
     };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -31,7 +31,7 @@ define(
       return Object(val);
     }
 
-    Object.assign = Object.assign || function (target, source) {
+    Object.assign = Object.assign || function (target /*, sources...*/) {
       var from;
       var keys;
       var to = ToObject(target);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -81,6 +81,7 @@ define(
           args.unshift(true);
         }
 
+        // add util extend function - is there an ES6 equiv?
         return $.extend.apply(undefined, args);
       },
 
@@ -234,6 +235,7 @@ define(
 
       delegate: function(rules) {
         return function(e, data) {
+          // how do we do closest?
           var target = $(e.target), parent;
 
           Object.keys(rules).forEach(function(selector) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -256,7 +256,7 @@ define(
       //     initialize();
       //
       // will only delete a record once
-      //   var myHanlder = function () {
+      //   var myHandler = function () {
       //     $.ajax({type: 'DELETE', url: 'someurl.com', data: {id: 1}});
       //   };
       //   this.on('click', utils.once(myHandler));

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -23,6 +23,31 @@ define(
       return writeProtectSupported;
     }
 
+    function ToObject(val) {
+      if (val == null) {
+        throw new TypeError('Object.assign cannot be called with null or undefined');
+      }
+
+      return Object(val);
+    }
+
+    Object.assign = Object.assign || function (target, source) {
+      var from;
+      var keys;
+      var to = ToObject(target);
+
+      for (var s = 1; s < arguments.length; s++) {
+        from = arguments[s];
+        keys = Object.keys(Object(from));
+
+        for (var i = 0; i < keys.length; i++) {
+          to[keys[i]] = from[keys[i]];
+        }
+      }
+
+      return to;
+    };
+
     var utils = {
 
       isDomObj: function(obj) {
@@ -59,30 +84,31 @@ define(
       //   merge(base, extra, true); //{a:4, b:{bb:4, cc:7, dd:1}}
       //   base; //{a:2, b:{bb:4, cc:5}};
 
-      merge: function(/*obj1, obj2,....deepCopy*/) {
-        // unpacking arguments by hand benchmarked faster
-        var l = arguments.length,
-            args = new Array(l + 1);
+      merge: function merge(/*obj1, obj2,....deepCopy*/) {
+        var len = arguments.length;
 
-        if (l === 0) {
+        if (len === 0) {
           return {};
         }
 
-        for (var i = 0; i < l; i++) {
-          args[i + 1] = arguments[i];
-        }
+        var args = [].slice.call(arguments);
 
-        //start with empty object so a copy is created
-        args[0] = {};
-
+        var deep = false;
         if (args[args.length - 1] === true) {
-          //jquery extend requires deep copy as first arg
           args.pop();
-          args.unshift(true);
+          deep = true;
         }
 
-        // add util extend function - is there an ES6 equiv?
-        return $.extend.apply(undefined, args);
+        return args.reduce(function (target, source) {
+          return Object.keys(source || {}).reduce(function (target, k) {
+            if (typeof source[k] === 'object' && deep) {
+              target[k] = merge(target[k] || {}, source[k]);
+            } else {
+              target[k] = source[k];
+            }
+            return target;
+          }, target)
+        }, {});
       },
 
       // updates base in place by copying properties of extra to it

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -259,11 +259,20 @@ define(
         };
       },
 
+      // Delegate event handling to a parent element using rules object
+      //
+      // Arguments:
+      //   contextElement is the element that the events will reach
+      //   rules is an object with selector keys and callback function values
+      //   dom is the DOM library adapter to use
       delegate: function(contextElement, rules, dom) {
         return function(event, data) {
+          // Where was the event actually fired?
           var target = event.target;
 
           Object.keys(rules).forEach(function(selector) {
+            // Is the target within an element that matches the selector, up to the contextElement.
+            // TODO: How slow is this?
             var parent = dom.closest(contextElement, target, selector);
             if (!event.isPropagationStopped() && parent) {
               data = data || {};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -290,11 +290,10 @@ define(
       //     initialize();
       //     initialize();
       //
-      // will only delete a record once
-      //   var myHandler = function () {
-      //     $.ajax({type: 'DELETE', url: 'someurl.com', data: {id: 1}});
-      //   };
-      //   this.on('click', utils.once(myHandler));
+      // will call the inner function once
+      //   this.on('click', utils.once(function () {
+      //     // ...
+      //   }));
       //
       once: function(func) {
         var ran, result;

--- a/test/spec/attribute_spec.js
+++ b/test/spec/attribute_spec.js
@@ -110,7 +110,7 @@ define(['lib/component', 'lib/debug'], function (defineComponent, debug) {
       var instance = (new TestComponent).initialize(document.body);
       expect(instance.attr.f).toBe(true);
 
-      var instance2 = (new TestComponent).initialize($('div').get(0));
+      var instance2 = (new TestComponent).initialize(document.createElement('div'));
       expect(instance2.attr.f).toBe(false);
 
       TestComponent.teardownAll();

--- a/test/spec/dom_spec.js
+++ b/test/spec/dom_spec.js
@@ -93,6 +93,12 @@ define(['lib/dom'], function (dom) {
         }).toThrow();
       });
 
+      it('throws when passed null', function () {
+        expect(function () {
+          dom.select(null);
+        }).toThrow();
+      });
+
       it('throws when passed other invalid value', function () {
         [true, NaN, {}].forEach(function (v) {
           expect(function () {
@@ -101,14 +107,75 @@ define(['lib/dom'], function (dom) {
         });
       });
 
-      it('throws when passed null', function () {
+      it('can select within a context element', function () {
+        expect(dom.select('.duplicate', child)).toBe(innerChild);
+      });
+
+    });
+
+    describe('selectALl', function () {
+
+      var root;
+      var child;
+      var innerChild;
+      var sibling;
+
+      beforeEach(function () {
+        root = document.createElement('div');
+        child = document.createElement('div');
+        innerChild = document.createElement('div');
+        sibling = document.createElement('div');
+
+        child.classList.add('child');
+        innerChild.classList.add('duplicate');
+        sibling.classList.add('duplicate');
+
+        child.appendChild(innerChild);
+        root.appendChild(child);
+        root.appendChild(sibling);
+        document.body.appendChild(root);
+      });
+
+      afterEach(function () {
+        document.body.removeChild(root);
+      });
+
+      it('can select elements via string', function () {
+        var matches = dom.selectAll('.duplicate');
+        expect(matches).toContain(sibling);
+        expect(matches).toContain(innerChild);
+      });
+
+      it('can select document via string', function () {
+        expect(dom.selectAll('document')).toEqual([document.documentElement]);
+      });
+
+      it('can select an element via reference', function () {
+        expect(dom.selectAll(root)).toEqual([root]);
+      });
+
+      it('throws when passed nothing', function () {
         expect(function () {
-          dom.select(null);
+          dom.selectAll();
         }).toThrow();
       });
 
+      it('throws when passed null', function () {
+        expect(function () {
+          dom.selectAll(null);
+        }).toThrow();
+      });
+
+      it('throws when passed other invalid value', function () {
+        [true, NaN, {}].forEach(function (v) {
+          expect(function () {
+            dom.selectAll(v);
+          }).toThrow();
+        });
+      });
+
       it('can select within a context element', function () {
-        expect(dom.select('.duplicate', child)).toBe(innerChild);
+        expect(dom.selectAll('.duplicate', child)).toEqual([innerChild]);
       });
 
     });

--- a/test/spec/dom_spec.js
+++ b/test/spec/dom_spec.js
@@ -1,0 +1,53 @@
+'use strict';
+
+define(['lib/dom'], function (dom) {
+
+  describe('(Core) dom', function () {
+
+    it('is requireable', function () {
+      expect(dom).toBeTruthy();
+    });
+
+    // TODO: select, selectAll, closest, wrapCallback, FlightEvent
+
+    describe('trigger/on', function () {
+
+      it('can listen to and trigger custom event', function () {
+        var spy = jasmine.createSpy();
+        dom.on(document, 'customEvent', spy);
+        dom.trigger(document.body, 'customEvent');
+        expect(spy).toHaveBeenCalled();
+      });
+
+      it('can listen to and trigger browser event', function () {
+        var spy = jasmine.createSpy();
+        dom.on(document, 'click', spy);
+        dom.trigger(document.body, 'click');
+        expect(spy).toHaveBeenCalled();
+      });
+
+    });
+
+    describe('off', function () {
+
+      it('can un-listen to custom event', function () {
+        var spy = jasmine.createSpy();
+        dom.on(document, 'customEvent', spy);
+        dom.off(document, 'customEvent', spy);
+        dom.trigger(document.body, 'customEvent');
+        expect(spy).not.toHaveBeenCalled();
+      });
+
+      it('can listen to and trigger browser event', function () {
+        var spy = jasmine.createSpy();
+        dom.on(document, 'click', spy);
+        dom.off(document, 'click', spy);
+        dom.trigger(document.body, 'click');
+        expect(spy).not.toHaveBeenCalled();
+      });
+
+    });
+
+  });
+
+});

--- a/test/spec/dom_spec.js
+++ b/test/spec/dom_spec.js
@@ -48,6 +48,71 @@ define(['lib/dom'], function (dom) {
 
     });
 
+    describe('select', function () {
+
+      var root;
+      var child;
+      var innerChild;
+      var sibling;
+
+      beforeEach(function () {
+        root = document.createElement('div');
+        child = document.createElement('div');
+        innerChild = document.createElement('div');
+        sibling = document.createElement('div');
+
+        child.classList.add('child');
+        innerChild.classList.add('duplicate');
+        sibling.classList.add('duplicate');
+
+        child.appendChild(innerChild);
+        root.appendChild(child);
+        root.appendChild(sibling);
+        document.body.appendChild(root);
+      });
+
+      afterEach(function () {
+        document.body.removeChild(root);
+      });
+
+      it('can select an element via string', function () {
+        expect(dom.select('.child')).toBe(child);
+      });
+
+      it('can select document via string', function () {
+        expect(dom.select('document')).toBe(document.documentElement);
+      });
+
+      it('can select an element via reference', function () {
+        expect(dom.select(root)).toBe(root);
+      });
+
+      it('throws when passed nothing', function () {
+        expect(function () {
+          dom.select();
+        }).toThrow();
+      });
+
+      it('throws when passed other invalid value', function () {
+        [true, NaN, {}].forEach(function (v) {
+          expect(function () {
+            dom.select(v);
+          }).toThrow();
+        });
+      });
+
+      it('throws when passed null', function () {
+        expect(function () {
+          dom.select(null);
+        }).toThrow();
+      });
+
+      it('can select within a context element', function () {
+        expect(dom.select('.duplicate', child)).toBe(innerChild);
+      });
+
+    });
+
   });
 
 });

--- a/test/spec/dom_spec.js
+++ b/test/spec/dom_spec.js
@@ -8,7 +8,7 @@ define(['lib/dom'], function (dom) {
       expect(dom).toBeTruthy();
     });
 
-    // TODO: select, selectAll, closest, wrapCallback, FlightEvent
+    // TODO: wrapCallback, FlightEvent
 
     describe('trigger/on', function () {
 
@@ -113,7 +113,7 @@ define(['lib/dom'], function (dom) {
 
     });
 
-    describe('selectALl', function () {
+    describe('selectAll', function () {
 
       var root;
       var child;
@@ -176,6 +176,62 @@ define(['lib/dom'], function (dom) {
 
       it('can select within a context element', function () {
         expect(dom.selectAll('.duplicate', child)).toEqual([innerChild]);
+      });
+
+    });
+
+    describe('closest', function () {
+
+      var root;
+      var child;
+      var innerChild;
+      var sibling;
+
+      beforeEach(function () {
+        root = document.createElement('div');
+        child = document.createElement('div');
+        sibling = document.createElement('div');
+        innerChild = document.createElement('div');
+
+        root.classList.add('context-target');
+        root.classList.add('multiple-target');
+        child.classList.add('parent-target');
+        child.classList.add('multiple-target');
+        sibling.classList.add('sibling-target');
+        innerChild.classList.add('possible-target');
+
+        child.appendChild(innerChild);
+        root.appendChild(child);
+        root.appendChild(sibling);
+        document.body.appendChild(root);
+      });
+
+      afterEach(function () {
+        document.body.removeChild(root);
+      });
+
+      it('will return nothing if nothing matches', function () {
+        expect(dom.closest(root, innerChild, '.no-matches')).toEqual(undefined);
+      });
+
+      it('will return the target if the target matches', function () {
+        expect(dom.closest(root, innerChild, '.possible-target')).toEqual(innerChild);
+      });
+
+      it('will return a parent if it matches', function () {
+        expect(dom.closest(root, innerChild, '.parent-target')).toEqual(child);
+      });
+
+      it('will return nothing if the match is not a parent', function () {
+        expect(dom.closest(root, innerChild, '.sibling-target')).toEqual(undefined);
+      });
+
+      it('will return nothing if the context element matches', function () {
+        expect(dom.closest(root, innerChild, '.context-target')).toEqual(undefined);
+      });
+
+      it('will return the closest match if there are multiple', function () {
+        expect(dom.closest(root, innerChild, '.multiple-target')).toEqual(child);
       });
 
     });

--- a/test/spec/dom_spec.js
+++ b/test/spec/dom_spec.js
@@ -8,7 +8,7 @@ define(['lib/dom'], function (dom) {
       expect(dom).toBeTruthy();
     });
 
-    // TODO: wrapCallback, FlightEvent
+    // TODO: FlightEvent
 
     describe('trigger/on', function () {
 
@@ -232,6 +232,36 @@ define(['lib/dom'], function (dom) {
 
       it('will return the closest match if there are multiple', function () {
         expect(dom.closest(root, innerChild, '.multiple-target')).toEqual(child);
+      });
+
+    });
+
+    describe('wrapCallback', function () {
+
+      it('maintains context', function () {
+        var ctx = {};
+        var nativeEvent = {};
+        var cb = dom.wrapCallback(function (event) {
+          expect(this).toEqual(ctx);
+        }, ctx);
+        cb(nativeEvent);
+      });
+
+      it('wraps argument in a FlightEvent', function () {
+        var nativeEvent = {};
+        var cb = dom.wrapCallback(function (event) {
+          expect(event).not.toEqual(nativeEvent);
+          expect(event instanceof dom.FlightEvent).toBe(true);
+        });
+        cb(nativeEvent);
+      });
+
+      it('passes event detail', function () {
+        var nativeEvent = { detail: {} };
+        var cb = dom.wrapCallback(function (event, data) {
+          expect(data).toEqual(nativeEvent.detail);
+        });
+        cb(nativeEvent);
       });
 
     });

--- a/test/spec/events_spec.js
+++ b/test/spec/events_spec.js
@@ -95,13 +95,13 @@ define(['lib/component', 'lib/registry'], function (defineComponent, registry) {
       expect(spy2).toHaveBeenCalled();
 
       //JQuery object
-      spy1 = jasmine.createSpy();
-      instance2.on('click', spy1);
-      spy2 = jasmine.createSpy();
-      instance3.on('click', spy2);
-      instance1.trigger($(document.body), 'click', {a:2});
-      expect(spy1).not.toHaveBeenCalled();
-      expect(spy2).toHaveBeenCalled();
+      // spy1 = jasmine.createSpy();
+      // instance2.on('click', spy1);
+      // spy2 = jasmine.createSpy();
+      // instance3.on('click', spy2);
+      // instance1.trigger($(document.body), 'click', {a:2});
+      // expect(spy1).not.toHaveBeenCalled();
+      // expect(spy2).toHaveBeenCalled();
     });
 
     it('unbinds listeners using "off"', function () {

--- a/test/spec/events_spec.js
+++ b/test/spec/events_spec.js
@@ -1,6 +1,6 @@
 "use strict";
 
-define(['lib/component', 'lib/registry'], function (defineComponent, registry) {
+define(['lib/component', 'lib/registry', 'lib/dom'], function (defineComponent, registry, dom) {
 
   describe("(Core) events", function () {
     var Component = (function () {
@@ -238,7 +238,7 @@ define(['lib/component', 'lib/registry'], function (defineComponent, registry) {
       instance.on(document, 'foo', spy);
       instance.trigger('foo', data);
       var args = spy.mostRecentCall.args;
-      expect(args[0]).toEqual(jasmine.any(Event));
+      expect(args[0]).toEqual(jasmine.any(dom.FlightEvent));
       expect(args[1]).toEqual(data);
     });
 
@@ -249,7 +249,7 @@ define(['lib/component', 'lib/registry'], function (defineComponent, registry) {
       instance.on(document, 'foo', spy);
       instance.trigger('foo', undefined);
       var args = spy.mostRecentCall.args;
-      expect(args[0]).toEqual(jasmine.any(Event));
+      expect(args[0]).toEqual(jasmine.any(dom.FlightEvent));
       expect(args[1]).not.toBeDefined();
     });
 

--- a/test/spec/events_spec.js
+++ b/test/spec/events_spec.js
@@ -238,7 +238,7 @@ define(['lib/component', 'lib/registry'], function (defineComponent, registry) {
       instance.on(document, 'foo', spy);
       instance.trigger('foo', data);
       var args = spy.mostRecentCall.args;
-      expect(args[0]).toEqual(jasmine.any($.Event));
+      expect(args[0]).toEqual(jasmine.any(Event));
       expect(args[1]).toEqual(data);
     });
 
@@ -249,7 +249,7 @@ define(['lib/component', 'lib/registry'], function (defineComponent, registry) {
       instance.on(document, 'foo', spy);
       instance.trigger('foo', undefined);
       var args = spy.mostRecentCall.args;
-      expect(args[0]).toEqual(jasmine.any($.Event));
+      expect(args[0]).toEqual(jasmine.any(Event));
       expect(args[1]).not.toBeDefined();
     });
 
@@ -276,57 +276,57 @@ define(['lib/component', 'lib/registry'], function (defineComponent, registry) {
       expect(returnedData.sheep).toBe('thrilling');
     });
 
-    it('executes the specified method when specified', function () {
-      var instance = (new Component).initialize(document.body);
-      instance.someMethod = jasmine.createSpy();
-      instance.trigger({ type: 'foo', defaultBehavior: 'someMethod' });
-      expect(instance.someMethod).toHaveBeenCalled();
-    });
+    // it('executes the specified method when specified', function () {
+    //   var instance = (new Component).initialize(document.body);
+    //   instance.someMethod = jasmine.createSpy();
+    //   instance.trigger({ type: 'foo', defaultBehavior: 'someMethod' });
+    //   expect(instance.someMethod).toHaveBeenCalled();
+    // });
 
-    it('executes the specified function when specified', function () {
-      var instance = (new Component).initialize(document.body);
-      var spy = jasmine.createSpy();
-      instance.trigger({ type: 'foo', defaultBehavior: spy });
-      expect(spy).toHaveBeenCalled();
-    });
+    // it('executes the specified function when specified', function () {
+    //   var instance = (new Component).initialize(document.body);
+    //   var spy = jasmine.createSpy();
+    //   instance.trigger({ type: 'foo', defaultBehavior: spy });
+    //   expect(spy).toHaveBeenCalled();
+    // });
 
-    it('does not execute the specified method when a listener calls preventDefault', function () {
-      var instance = (new Component).initialize(document.body);
-      instance.someMethod = jasmine.createSpy();
+    // it('does not execute the specified method when a listener calls preventDefault', function () {
+    //   var instance = (new Component).initialize(document.body);
+    //   instance.someMethod = jasmine.createSpy();
 
-      instance.on('foo', function (e) {
-        e.preventDefault();
-      });
+    //   instance.on('foo', function (e) {
+    //     e.preventDefault();
+    //   });
 
-      instance.trigger({ type: 'foo', defaultBehavior: 'someMethod' });
-      expect(instance.someMethod).not.toHaveBeenCalled();
-    });
+    //   instance.trigger({ type: 'foo', defaultBehavior: 'someMethod' });
+    //   expect(instance.someMethod).not.toHaveBeenCalled();
+    // });
 
-    it('does not execute the specified function when a listener calls preventDefault', function () {
-      var instance = (new Component).initialize(document.body);
-      var spy = jasmine.createSpy();
+    // it('does not execute the specified function when a listener calls preventDefault', function () {
+    //   var instance = (new Component).initialize(document.body);
+    //   var spy = jasmine.createSpy();
 
-      instance.on('foo', function (e) {
-        e.preventDefault();
-      });
+    //   instance.on('foo', function (e) {
+    //     e.preventDefault();
+    //   });
 
-      instance.trigger({ type: 'foo', defaultBehavior: spy });
-      expect(spy).not.toHaveBeenCalled();
-    });
+    //   instance.trigger({ type: 'foo', defaultBehavior: spy });
+    //   expect(spy).not.toHaveBeenCalled();
+    // });
 
-    it('merges eventData into triggered default behavior event data', function () {
-      var instance = (new Component).initialize(document.body, { eventData: { penguins: 'cool', sheep: 'dull' } });
-      var data = { sheep: 'thrilling' };
+    // it('merges eventData into triggered default behavior event data', function () {
+    //   var instance = (new Component).initialize(document.body, { eventData: { penguins: 'cool', sheep: 'dull' } });
+    //   var data = { sheep: 'thrilling' };
 
-      var spy = jasmine.createSpy();
-      instance.trigger({ type: 'foo', defaultBehavior: spy }, data);
-      var args = spy.mostRecentCall.args;
-      var returnedData = args[1];
-      expect(returnedData.penguins).toBeDefined();
-      expect(returnedData.penguins).toBe('cool');
-      expect(returnedData.sheep).toBeDefined();
-      expect(returnedData.sheep).toBe('thrilling');
-    });
+    //   var spy = jasmine.createSpy();
+    //   instance.trigger({ type: 'foo', defaultBehavior: spy }, data);
+    //   var args = spy.mostRecentCall.args;
+    //   var returnedData = args[1];
+    //   expect(returnedData.penguins).toBeDefined();
+    //   expect(returnedData.penguins).toBe('cool');
+    //   expect(returnedData.sheep).toBeDefined();
+    //   expect(returnedData.sheep).toBe('thrilling');
+    // });
 
   });
 });

--- a/test/spec/events_spec.js
+++ b/test/spec/events_spec.js
@@ -267,57 +267,5 @@ define(['lib/component', 'lib/registry', 'lib/dom'], function (defineComponent, 
       expect(returnedData.sheep).toBe('thrilling');
     });
 
-    // it('executes the specified method when specified', function () {
-    //   var instance = (new Component).initialize(document.body);
-    //   instance.someMethod = jasmine.createSpy();
-    //   instance.trigger({ type: 'foo', defaultBehavior: 'someMethod' });
-    //   expect(instance.someMethod).toHaveBeenCalled();
-    // });
-
-    // it('executes the specified function when specified', function () {
-    //   var instance = (new Component).initialize(document.body);
-    //   var spy = jasmine.createSpy();
-    //   instance.trigger({ type: 'foo', defaultBehavior: spy });
-    //   expect(spy).toHaveBeenCalled();
-    // });
-
-    // it('does not execute the specified method when a listener calls preventDefault', function () {
-    //   var instance = (new Component).initialize(document.body);
-    //   instance.someMethod = jasmine.createSpy();
-
-    //   instance.on('foo', function (e) {
-    //     e.preventDefault();
-    //   });
-
-    //   instance.trigger({ type: 'foo', defaultBehavior: 'someMethod' });
-    //   expect(instance.someMethod).not.toHaveBeenCalled();
-    // });
-
-    // it('does not execute the specified function when a listener calls preventDefault', function () {
-    //   var instance = (new Component).initialize(document.body);
-    //   var spy = jasmine.createSpy();
-
-    //   instance.on('foo', function (e) {
-    //     e.preventDefault();
-    //   });
-
-    //   instance.trigger({ type: 'foo', defaultBehavior: spy });
-    //   expect(spy).not.toHaveBeenCalled();
-    // });
-
-    // it('merges eventData into triggered default behavior event data', function () {
-    //   var instance = (new Component).initialize(document.body, { eventData: { penguins: 'cool', sheep: 'dull' } });
-    //   var data = { sheep: 'thrilling' };
-
-    //   var spy = jasmine.createSpy();
-    //   instance.trigger({ type: 'foo', defaultBehavior: spy }, data);
-    //   var args = spy.mostRecentCall.args;
-    //   var returnedData = args[1];
-    //   expect(returnedData.penguins).toBeDefined();
-    //   expect(returnedData.penguins).toBe('cool');
-    //   expect(returnedData.sheep).toBeDefined();
-    //   expect(returnedData.sheep).toBe('thrilling');
-    // });
-
   });
 });

--- a/test/spec/events_spec.js
+++ b/test/spec/events_spec.js
@@ -93,15 +93,6 @@ define(['lib/component', 'lib/registry', 'lib/dom'], function (defineComponent, 
       instance1.trigger('body', 'click', {a:2});
       expect(spy1).not.toHaveBeenCalled();
       expect(spy2).toHaveBeenCalled();
-
-      //JQuery object
-      // spy1 = jasmine.createSpy();
-      // instance2.on('click', spy1);
-      // spy2 = jasmine.createSpy();
-      // instance3.on('click', spy2);
-      // instance1.trigger($(document.body), 'click', {a:2});
-      // expect(spy1).not.toHaveBeenCalled();
-      // expect(spy2).toHaveBeenCalled();
     });
 
     it('unbinds listeners using "off"', function () {

--- a/test/spec/logger_spec.js
+++ b/test/spec/logger_spec.js
@@ -46,31 +46,31 @@ define(['lib/component', 'lib/debug'], function(defineComponent, debug) {
         expect(console.info).toHaveBeenCalledWith('->', 'trigger', '[click]', data, '\'div#myDiv.myDiv\'', '');
       });
 
-      it('logs trigger with event object', function () {
-        spyOn(console, 'info');
-        instance.trigger({type:'click'});
-        expect(console.info).toHaveBeenCalledWith('->', 'trigger', '[click]', '\'div#myDiv.myDiv\'', '');
-      });
+      // it('logs trigger with event object', function () {
+      //   spyOn(console, 'info');
+      //   instance.trigger({type:'click'});
+      //   expect(console.info).toHaveBeenCalledWith('->', 'trigger', '[click]', '\'div#myDiv.myDiv\'', '');
+      // });
 
-      it('logs trigger for custom node with event object', function () {
-        spyOn(console, 'info');
-        instance.trigger('document', {type:'click'});
-        expect(console.info).toHaveBeenCalledWith('->', 'trigger', '[click]', 'document', '');
-      });
+      // it('logs trigger for custom node with event object', function () {
+      //   spyOn(console, 'info');
+      //   instance.trigger('document', {type:'click'});
+      //   expect(console.info).toHaveBeenCalledWith('->', 'trigger', '[click]', 'document', '');
+      // });
 
-      it('logs trigger with event object and payload', function () {
-        var data = {a:2};
-        spyOn(console, 'info');
-        instance.trigger({type:'click'}, data);
-        expect(console.info).toHaveBeenCalledWith('->', 'trigger', '[click]', data, '\'div#myDiv.myDiv\'', '');
-      });
+      // it('logs trigger with event object and payload', function () {
+      //   var data = {a:2};
+      //   spyOn(console, 'info');
+      //   instance.trigger({type:'click'}, data);
+      //   expect(console.info).toHaveBeenCalledWith('->', 'trigger', '[click]', data, '\'div#myDiv.myDiv\'', '');
+      // });
 
-      it('logs trigger for custom node with event object and payload', function () {
-        var data = {a:2};
-        spyOn(console, 'info');
-        instance.trigger('document', {type:'click'}, data);
-        expect(console.info).toHaveBeenCalledWith('->', 'trigger', '[click]', data, 'document', '');
-      });
+      // it('logs trigger for custom node with event object and payload', function () {
+      //   var data = {a:2};
+      //   spyOn(console, 'info');
+      //   instance.trigger('document', {type:'click'}, data);
+      //   expect(console.info).toHaveBeenCalledWith('->', 'trigger', '[click]', data, 'document', '');
+      // });
     });
 
     describe('on logging', function () {
@@ -142,22 +142,22 @@ define(['lib/component', 'lib/debug'], function(defineComponent, debug) {
         expect(console.info).not.toHaveBeenCalled();
       });
 
-      it('only logs filtered event objects', function () {
-        debug.events.logByName('click', 'clack');
-        spyOn(console, 'info');
-        instance.trigger({type:'click'});
-        expect(console.info).toHaveBeenCalled();
+      // it('only logs filtered event objects', function () {
+      //   debug.events.logByName('click', 'clack');
+      //   spyOn(console, 'info');
+      //   instance.trigger({type:'click'});
+      //   expect(console.info).toHaveBeenCalled();
 
-        console.info.isSpy = false;
-        spyOn(console, 'info');
-        instance.on({type:'clack'}, instance.handler);
-        expect(console.info).toHaveBeenCalled();
+      //   console.info.isSpy = false;
+      //   spyOn(console, 'info');
+      //   instance.on({type:'clack'}, instance.handler);
+      //   expect(console.info).toHaveBeenCalled();
 
-        console.info.isSpy = false;
-        spyOn(console, 'info');
-        instance.off({type:'cluck'}, instance.handler);
-        expect(console.info).not.toHaveBeenCalled();
-      });
+      //   console.info.isSpy = false;
+      //   spyOn(console, 'info');
+      //   instance.off({type:'cluck'}, instance.handler);
+      //   expect(console.info).not.toHaveBeenCalled();
+      // });
 
       it('logs nothing when filter set to none', function () {
         debug.events.logNone();

--- a/test/spec/logger_spec.js
+++ b/test/spec/logger_spec.js
@@ -4,8 +4,14 @@ define(['lib/component', 'lib/debug'], function(defineComponent, debug) {
 
   var instance;
   var Component;
-  var div = $('<div id="myDiv" class="myDiv"></div>').appendTo('body')[0];
-  var span = $('<span class="mySpan"></span>').appendTo('body')[0];
+
+  var div = document.createElement('div');
+  var span = document.createElement('span');
+  div.id = 'myDiv';
+  div.classList.add('myDiv');
+  span.classList.add('mySpan');
+  document.body.appendChild(div);
+  document.body.appendChild(span);
 
   describe('(Core) logger', function () {
 

--- a/test/spec/logger_spec.js
+++ b/test/spec/logger_spec.js
@@ -148,22 +148,22 @@ define(['lib/component', 'lib/debug'], function(defineComponent, debug) {
         expect(console.info).not.toHaveBeenCalled();
       });
 
-      // it('only logs filtered event objects', function () {
-      //   debug.events.logByName('click', 'clack');
-      //   spyOn(console, 'info');
-      //   instance.trigger({type:'click'});
-      //   expect(console.info).toHaveBeenCalled();
+      it('only logs filtered event objects', function () {
+        debug.events.logByName('click', 'clack');
+        spyOn(console, 'info');
+        instance.trigger({type:'click'});
+        expect(console.info).toHaveBeenCalled();
 
-      //   console.info.isSpy = false;
-      //   spyOn(console, 'info');
-      //   instance.on({type:'clack'}, instance.handler);
-      //   expect(console.info).toHaveBeenCalled();
+        console.info.isSpy = false;
+        spyOn(console, 'info');
+        instance.on({type:'clack'}, instance.handler);
+        expect(console.info).toHaveBeenCalled();
 
-      //   console.info.isSpy = false;
-      //   spyOn(console, 'info');
-      //   instance.off({type:'cluck'}, instance.handler);
-      //   expect(console.info).not.toHaveBeenCalled();
-      // });
+        console.info.isSpy = false;
+        spyOn(console, 'info');
+        instance.off({type:'cluck'}, instance.handler);
+        expect(console.info).not.toHaveBeenCalled();
+      });
 
       it('logs nothing when filter set to none', function () {
         debug.events.logNone();

--- a/test/spec/logger_spec.js
+++ b/test/spec/logger_spec.js
@@ -46,31 +46,31 @@ define(['lib/component', 'lib/debug'], function(defineComponent, debug) {
         expect(console.info).toHaveBeenCalledWith('->', 'trigger', '[click]', data, '\'div#myDiv.myDiv\'', '');
       });
 
-      // it('logs trigger with event object', function () {
-      //   spyOn(console, 'info');
-      //   instance.trigger({type:'click'});
-      //   expect(console.info).toHaveBeenCalledWith('->', 'trigger', '[click]', '\'div#myDiv.myDiv\'', '');
-      // });
+      it('logs trigger with event object', function () {
+        spyOn(console, 'info');
+        instance.trigger({type:'click'});
+        expect(console.info).toHaveBeenCalledWith('->', 'trigger', '[click]', '\'div#myDiv.myDiv\'', '');
+      });
 
-      // it('logs trigger for custom node with event object', function () {
-      //   spyOn(console, 'info');
-      //   instance.trigger('document', {type:'click'});
-      //   expect(console.info).toHaveBeenCalledWith('->', 'trigger', '[click]', 'document', '');
-      // });
+      it('logs trigger for custom node with event object', function () {
+        spyOn(console, 'info');
+        instance.trigger('document', {type:'click'});
+        expect(console.info).toHaveBeenCalledWith('->', 'trigger', '[click]', 'document', '');
+      });
 
-      // it('logs trigger with event object and payload', function () {
-      //   var data = {a:2};
-      //   spyOn(console, 'info');
-      //   instance.trigger({type:'click'}, data);
-      //   expect(console.info).toHaveBeenCalledWith('->', 'trigger', '[click]', data, '\'div#myDiv.myDiv\'', '');
-      // });
+      it('logs trigger with event object and payload', function () {
+        var data = {a:2};
+        spyOn(console, 'info');
+        instance.trigger({type:'click'}, data);
+        expect(console.info).toHaveBeenCalledWith('->', 'trigger', '[click]', data, '\'div#myDiv.myDiv\'', '');
+      });
 
-      // it('logs trigger for custom node with event object and payload', function () {
-      //   var data = {a:2};
-      //   spyOn(console, 'info');
-      //   instance.trigger('document', {type:'click'}, data);
-      //   expect(console.info).toHaveBeenCalledWith('->', 'trigger', '[click]', data, 'document', '');
-      // });
+      it('logs trigger for custom node with event object and payload', function () {
+        var data = {a:2};
+        spyOn(console, 'info');
+        instance.trigger('document', {type:'click'}, data);
+        expect(console.info).toHaveBeenCalledWith('->', 'trigger', '[click]', data, 'document', '');
+      });
     });
 
     describe('on logging', function () {

--- a/test/spec/registry_spec.js
+++ b/test/spec/registry_spec.js
@@ -53,7 +53,7 @@ define(['lib/component', 'lib/registry'], function (defineComponent, registry) {
       var instance = (new Component).initialize(window.outerDiv);
       var instanceInfo = registry.allInstances[instance.identity];
 
-      var myFunction = $.noop;
+      var myFunction = function () {};
       instance.on("myEvent", myFunction);
       expect(instanceInfo.events.length).toBe(1);
 

--- a/test/spec/utils_spec.js
+++ b/test/spec/utils_spec.js
@@ -1,6 +1,6 @@
 "use strict";
 
-define(['lib/component', 'lib/utils', 'lib/debug'], function (defineComponent, utils, debug) {
+define(['lib/component', 'lib/utils', 'lib/debug', 'lib/dom'], function (defineComponent, utils, debug, dom) {
 
   describe('(Core) utils', function () {
 
@@ -252,38 +252,37 @@ define(['lib/component', 'lib/utils', 'lib/debug'], function (defineComponent, u
 
       jasmine.Clock.useMock();
       var spy = jasmine.createSpy();
-      instance.on('click', {bodySelector: spy});
+      instance.on('customEvent', {bodySelector: spy});
 
-      $(document.body).trigger('click', myData);
+      dom.trigger(document.body, 'customEvent', myData);
 
       var callbackArgs = spy.mostRecentCall.args;
-      expect(spy).toHaveBeenCalledWith(jasmine.any($.Event), myData);
+      expect(spy).toHaveBeenCalledWith(jasmine.any(dom.FlightEvent), myData);
       expect(callbackArgs[1].el).toBe(document.body);
     });
 
     it('should pass the correct currentTarget', function () {
       var instance = (new Component).initialize(document, {'bodySelector': 'body'});
 
-      instance.on('click', {
+      instance.on('customEvent', {
         bodySelector: function (event) {
           expect(event.currentTarget).toBe(document.body);
         }
       });
 
-      $(window.div).trigger('click');
+      dom.trigger(window.div, 'customEvent');
     });
 
     it('makes "this" in delegated function references be the component instance', function () {
       var instance = (new Component).initialize(document, {'bodySelector': 'body'});
 
-      instance.on('click', {
+      instance.on('customEvent', {
         bodySelector: function (event) {
           expect(this).toBe(instance);
         }
       });
 
-      $(document.body).trigger('click');
-
+      dom.trigger(document.body, 'customEvent');
     });
 
     it('should invoke all matching handlers if stopPropagation not called on event', function () {
@@ -292,7 +291,7 @@ define(['lib/component', 'lib/utils', 'lib/debug'], function (defineComponent, u
       var spy1 = jasmine.createSpy();
       var spy2 = jasmine.createSpy();
 
-      instance.on('click', {
+      instance.on('customEvent', {
         'divSelector': function (event) {
           spy1();
         },
@@ -301,7 +300,7 @@ define(['lib/component', 'lib/utils', 'lib/debug'], function (defineComponent, u
         }
       });
 
-      $('div').trigger('click');
+      dom.trigger('div', 'customEvent');
       expect(spy1).toHaveBeenCalled();
       expect(spy2).toHaveBeenCalled();
     });
@@ -313,7 +312,7 @@ define(['lib/component', 'lib/utils', 'lib/debug'], function (defineComponent, u
       var spy1 = jasmine.createSpy();
       var spy2 = jasmine.createSpy();
 
-      instance.on('click', {
+      instance.on('customEvent', {
         'divSelector': function (event) {
           event.stopPropagation();
           spy1();
@@ -323,7 +322,7 @@ define(['lib/component', 'lib/utils', 'lib/debug'], function (defineComponent, u
         }
       });
 
-      $('div').trigger('click');
+      dom.trigger('div', 'customEvent');
       expect(spy1).toHaveBeenCalled();
       expect(spy2).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
:rocket: 

It's happening.

In the process, a couple 'features' have gone:

- `this.$node`. Just use `this.node` instead.
- `defaultBehaviour` in for triggered events. Just use event handlers.

There's more work to do, because we've to build and support a jQuery DOM implementation, but this PR contains the basic spec for a Flight-compatible DOM library (see `dom_spec.js`).

Booyah.